### PR TITLE
Correct deprecation on deps/build.jl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -53,11 +53,11 @@ end
     provides(Homebrew.HB, "gdk-pixbuf", gdk_pixbuf, os = :Darwin)
 end
 
-@BinDeps.install [
+@BinDeps.install Dict(
     :glib => :libglib,
     :gobject => :libgobject,
     :gtk => :libgtk,
     :gdk => :libgdk,
     :gdk_pixbuf => :libgdk_pixbuf,
     :gio => :libgio,
-]
+)


### PR DESCRIPTION
Corrected the following deprecation issue on `Julia 0.4.0-dev+4968` commit `b85ede9`:

```julia
WARNING: deprecated syntax "[a=>b, ...]" at ...
Use "Dict(a=>b, ...)" instead.
```