### PR TITLE
Fix warning about conflicting identifiers

### DIFF
--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -18,7 +18,11 @@ import Base: convert, show, showall, run, size, resize!, length, getindex, setin
              select!, start, next, done, parent, isempty, empty!, first, last, in,
              eltype, copy, isvalid, string, sigatomic_begin, sigatomic_end
 
-import Graphics: width, height, getgc
+if VERSION < v"0.4.0-dev+3275"
+    import Base.Graphics: width, height, getgc
+else
+    import Graphics: width, height, getgc
+end
 
 using Cairo
 import Cairo: destroy

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -1,5 +1,12 @@
 ## Tests
-using Gtk.ShortNames, Gtk.GConstants, Graphics
+using Gtk.ShortNames, Gtk.GConstants
+
+if VERSION < v"0.4.0-dev+3275"
+    import Base.Graphics
+else
+    import Graphics
+end
+
 import Gtk.deleteat!
 import Gtk.GLib.Compat: int32, int8, uint32
 


### PR DESCRIPTION
Fix for #150 using the construct from Tk.jl (see [here](https://github.com/JuliaLang/Tk.jl/blob/master/src/Tk.jl#L27-L31)).