### PR TITLE
Emit helpful information for invalid return type in callback

### DIFF
--- a/src/GLib/signals.jl
+++ b/src/GLib/signals.jl
@@ -95,7 +95,16 @@ function GClosureMarshal(closuref, return_value, n_param_values,
     if return_value != C_NULL && retval !== nothing
         gtyp = unsafe_load(return_value).g_type
         if gtyp != g_type(Void) && gtyp != 0
-            return_value[] = gvalue(retval)
+            try
+                return_value[] = gvalue(retval)
+            catch
+                if isgeneric(cb)
+                    warn("Executing ", cb, ":")
+                else
+                    warn("Executing ", Base.uncompressed_ast(cb.code).args[3].args[1])   # just show file/line
+                end
+                error("Error setting return value of type $(typeof(retval)); did your callback return an unintentional value?")
+            end
         end
     end
     return nothing

--- a/src/GLib/signals.jl
+++ b/src/GLib/signals.jl
@@ -88,7 +88,7 @@ function GClosureMarshal(closuref, return_value, n_param_values,
         end
     end
     local retval = nothing
-    g_siginterruptible() do
+    g_siginterruptible(cb) do
         # note: make sure not to leak any of the GValue objects into this task switch, since many of them were alloca'd
         retval = cb(params...) # widget, args...
     end
@@ -98,16 +98,20 @@ function GClosureMarshal(closuref, return_value, n_param_values,
             try
                 return_value[] = gvalue(retval)
             catch
-                if isgeneric(cb)
-                    warn("Executing ", cb, ":")
-                else
-                    warn("Executing ", Base.uncompressed_ast(cb.code).args[3].args[1])   # just show file/line
-                end
+                blame(cb)
                 error("Error setting return value of type $(typeof(retval)); did your callback return an unintentional value?")
             end
         end
     end
     return nothing
+end
+
+function blame(cb)
+    if isgeneric(cb)
+        warn("Executing ", cb, ":")
+    else
+        warn("Executing ", Base.uncompressed_ast(cb.code).args[3].args[1])   # just show file/line
+    end
 end
 
 # Signals API for the cb pointer
@@ -210,7 +214,7 @@ else
     _get_return() = current_task().last
 end
 
-function g_siginterruptible(f::Base.Callable)
+function g_siginterruptible(f::Base.Callable, cb)
     global g_sigatom_flag, gtk_stack, gtk_work
     prev = g_sigatom_flag
     @assert prev $ (current_task() !== gtk_stack)
@@ -280,6 +284,7 @@ function g_siginterruptible(f::Base.Callable)
             end
         end
     catch err
+        blame(cb)
         ct = current_task()
         filter!(x->x!==ct, Base.Workqueue)
         if f !== yield
@@ -387,7 +392,7 @@ function uv_dispatch{T}(src::Ptr{Void},callback::Ptr{Void},data::T)
 end
 
 function g_yield(data)
-    g_siginterruptible(yield)
+    g_siginterruptible(yield, yield)
     return int32(true)
 end
 


### PR DESCRIPTION
I had a callback that inadvertently returned an unrecognized object, and it took me longer to figure out how to debug it than it should have. This was the backtrace:
```jl
FATAL ERROR: Gtk state corrupted by error thrown in a callback:
ERROR: MethodError: `g_type` has no method matching g_type(::Type{GtkUtilities.Link.State{GtkUtilities.PanZoom.Interval{Float64}}})
 in setindex! at /home/tim/.julia/v0.4/Gtk/src/GLib/gvalues.jl:64
 in setindex! at /home/tim/.julia/v0.4/Gtk/src/GLib/gvalues.jl:42
 in gvalue at /home/tim/.julia/v0.4/Gtk/src/GLib/gvalues.jl:13
 in gvalue at /home/tim/.julia/v0.4/Gtk/src/GLib/gvalues.jl:18
 in GClosureMarshal at /home/tim/.julia/v0.4/Gtk/src/GLib/signals.jl:98

ERROR (unhandled task failure): MethodError: `g_type` has no method matching g_type(::Type{GtkUtilities.Link.State{GtkUtilities.PanZoom.Interval{Float64}}})
 in setindex! at /home/tim/.julia/v0.4/Gtk/src/GLib/gvalues.jl:64
 in setindex! at /home/tim/.julia/v0.4/Gtk/src/GLib/gvalues.jl:42
 in gvalue at /home/tim/.julia/v0.4/Gtk/src/GLib/gvalues.jl:13
 in gvalue at /home/tim/.julia/v0.4/Gtk/src/GLib/gvalues.jl:18
 in GClosureMarshal at /home/tim/.julia/v0.4/Gtk/src/GLib/signals.jl:98
```

Now the error message looks like this:
```jl
WARNING: Executing  # /home/tim/.julia/v0.4/GtkUtilities/src/panzoom.jl, line 317:
FATAL ERROR: Gtk state corrupted by error thrown in a callback:
ERROR: Error setting return value of type GtkUtilities.Link.State{GtkUtilities.PanZoom.Interval{Float64}}; did your callback return an unintentional value?
 in error at ./error.jl:21
 in GClosureMarshal at /home/tim/.julia/v0.4/Gtk/src/GLib/signals.jl:106
```
(The key point being that the file and line number is shown.)

I'm not sure if my digging into the AST is done as well as it should be, and obviously it's fragile to changes in julia.
