### PR TITLE
Fix binding deprecations and bump julia version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: false
 os:
     - linux
 julia:
-    - release
-    - nightly
+    - 0.4
 notifications:
     email: false
 addons:
@@ -19,9 +18,7 @@ script:
           println(BinDeps.debug("Gtk"));
           Pkg.test("Gtk"; coverage=true)'
 after_success:
-    - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then
-          julia -e 'cd(Pkg.dir("Gtk"));
-              Pkg.add("Coverage");
-              using Coverage;
-              Coveralls.submit(Coveralls.process_folder())';
-      fi
+    - julia -e 'cd(Pkg.dir("Gtk"));
+                Pkg.add("Coverage");
+                using Coverage;
+                Coveralls.submit(Coveralls.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
+julia 0.4-
 Cairo 0.2.2
-julia 0.2
 Graphics 0.1
 BinDeps
 @windows WinRPM

--- a/gen/gtk_auto_gen.jl
+++ b/gen/gtk_auto_gen.jl
@@ -9,7 +9,7 @@ function without_linenums!(ex::Expr)
     linenums_filter(x,ex) = true
     linenums_filter(x::LineNumberNode,ex) = false
     linenums_filter(x::Expr,ex) = x.head !== :line
-    linenums_filter(x::Nothing,ex) = ex.head !== :block
+    linenums_filter(x::Void,ex) = ex.head !== :block
     filter!((x)->linenums_filter(x,ex), ex.args)
     for arg in ex.args
         if isa(arg,Expr)

--- a/gen/gtk_list_gen.jl
+++ b/gen/gtk_list_gen.jl
@@ -98,7 +98,7 @@ function gen_g_type_lists(gtk_h)
                         name = gensym()
                     end
                     jtyp = g_type_to_jl(cindex.getCursorType(cu))
-                    if jtyp === :Nothing
+                    if jtyp === :Void
                         jtyp = " < $(cindex.getCursorType(cu)) >"
                         valid = false
                     end

--- a/src/GLib/GLib.jl
+++ b/src/GLib/GLib.jl
@@ -58,10 +58,10 @@ end
 importall .Compat
 
 # local function, handles Symbol and makes UTF8-strings easier
-typealias StringLike Union(String,Symbol)
+typealias AbstractStringLike Union(AbstractString,Symbol)
 bytestring(s) = Base.bytestring(s)
 bytestring(s::Symbol) = s
-bytestring(s::Ptr{Uint8},own::Bool) = UTF8String(pointer_to_array(s,int(ccall(:strlen,Csize_t,(Ptr{Uint8},),s)),own))
+bytestring(s::Ptr{UInt8},own::Bool) = UTF8String(pointer_to_array(s,int(ccall(:strlen,Csize_t,(Ptr{UInt8},),s)),own))
 
 include(joinpath("..","..","deps","ext_glib.jl"))
 

--- a/src/GLib/gerror.jl
+++ b/src/GLib/gerror.jl
@@ -1,7 +1,7 @@
 immutable GError
-    domain::Uint32
+    domain::UInt32
     code::Cint
-    message::Ptr{Uint8}
+    message::Ptr{UInt8}
 end
 make_gvalue(GError, Ptr{GError}, :boxed, (:g_error,:libgobject))
 convert(::Type{GError}, err::Ptr{GError}) = GError(err)

--- a/src/GLib/glist.jl
+++ b/src/GLib/glist.jl
@@ -215,12 +215,12 @@ empty!{N<:Number}(li::Ptr{_GSList{Ptr{N}}}) = c_free(unsafe_load(li).data)
 empty!{N<:Number}(li::Ptr{_GList{Ptr{N}}}) = c_free(unsafe_load(li).data)
 
 ### Store (byte)strings as pointers
-deref_to{S<:ByteString}(::Type{S}, p::Ptr) = bytestring(convert(Ptr{Uint8},p))
+deref_to{S<:ByteString}(::Type{S}, p::Ptr) = bytestring(convert(Ptr{UInt8},p))
 function ref_to{S<:ByteString}(::Type{S}, x)
     s = bytestring(x)
     l = sizeof(s)
-    p = convert(Ptr{Uint8},c_malloc(l+1))
-    unsafe_copy!(p,convert(Ptr{Uint8},pointer(s)),l)
+    p = convert(Ptr{UInt8},c_malloc(l+1))
+    unsafe_copy!(p,convert(Ptr{UInt8},pointer(s)),l)
     unsafe_store!(p,'\0',l+1)
     return p
 end

--- a/src/GLib/gtype.jl
+++ b/src/GLib/gtype.jl
@@ -23,14 +23,14 @@ const fundamental_types = (
     (:gchar,      Int8,             Int8,           :schar),
     (:guchar,     UInt8,            UInt8,          :uchar),
     (:gboolean,   Cint,             Bool,           :boolean),
-    (:gint,       Cint,             Union(),           :int),
-    (:guint,      Cuint,            Union(),           :uint),
-    (:glong,      Clong,            Union(),           :long),
-    (:gulong,     Culong,           Union(),           :ulong),
+    (:gint,       Cint,             Union{},           :int),
+    (:guint,      Cuint,            Union{},           :uint),
+    (:glong,      Clong,            Union{},           :long),
+    (:gulong,     Culong,           Union{},           :ulong),
     (:gint64,     Int64,            Signed,         :int64),
     (:guint64,    UInt64,           Unsigned,       :uint64),
-    (:GEnum,      GEnum,            Union(),           :enum),
-    (:GFlags,     GEnum,            Union(),           :flags),
+    (:GEnum,      GEnum,            Union{},           :enum),
+    (:GFlags,     GEnum,            Union{},           :flags),
     (:gfloat,     Float32,          Float32,        :float),
     (:gdouble,    Float64,          AbstractFloat,  :double),
     (:gchararray, Ptr{UInt8},       AbstractString,         :string),
@@ -48,7 +48,7 @@ g_type(gtyp::GType) = gtyp
 let jtypes = Expr(:block, :( g_type(::Type{Void}) = $(g_type_from_name(:void)) ))
     for i = 1:length(fundamental_types)
         (name, ctype, juliatype, g_value_fn) = fundamental_types[i]
-        if juliatype !== Union()
+        if juliatype !== Union{}
             push!(jtypes.args, :( g_type{T<:$juliatype}(::Type{T}) = convert(GType,$(fundamental_ids[i])) ))
         end
     end

--- a/src/GLib/gtype.jl
+++ b/src/GLib/gtype.jl
@@ -9,7 +9,7 @@ typealias GEnum Int32
 typealias GType Csize_t
 immutable GParamSpec
   g_type_instance::Ptr{Void}
-  name::Ptr{Uint8}
+  name::Ptr{UInt8}
   flags::Cint
   value_type::GType
   owner_type::GType
@@ -18,22 +18,22 @@ end
 const fundamental_types = (
     #(:name,      Ctype,            JuliaType,      g_value_fn)
     (:invalid,    Void,             Void,           :error),
-    (:void,       Nothing,          Nothing,        :error),
+    (:void,       Void,          Void,        :error),
     (:GInterface, Ptr{Void},        GInterface,     :error),
     (:gchar,      Int8,             Int8,           :schar),
-    (:guchar,     Uint8,            Uint8,          :uchar),
+    (:guchar,     UInt8,            UInt8,          :uchar),
     (:gboolean,   Cint,             Bool,           :boolean),
-    (:gint,       Cint,             None,           :int),
-    (:guint,      Cuint,            None,           :uint),
-    (:glong,      Clong,            None,           :long),
-    (:gulong,     Culong,           None,           :ulong),
+    (:gint,       Cint,             Union(),           :int),
+    (:guint,      Cuint,            Union(),           :uint),
+    (:glong,      Clong,            Union(),           :long),
+    (:gulong,     Culong,           Union(),           :ulong),
     (:gint64,     Int64,            Signed,         :int64),
-    (:guint64,    Uint64,           Unsigned,       :uint64),
-    (:GEnum,      GEnum,            None,           :enum),
-    (:GFlags,     GEnum,            None,           :flags),
+    (:guint64,    UInt64,           Unsigned,       :uint64),
+    (:GEnum,      GEnum,            Union(),           :enum),
+    (:GFlags,     GEnum,            Union(),           :flags),
     (:gfloat,     Float32,          Float32,        :float),
-    (:gdouble,    Float64,          FloatingPoint,  :double),
-    (:gchararray, Ptr{Uint8},       String,         :string),
+    (:gdouble,    Float64,          AbstractFloat,  :double),
+    (:gchararray, Ptr{UInt8},       AbstractString,         :string),
     (:gpointer,   Ptr{Void},        Ptr,            :pointer),
     (:GBoxed,     Ptr{GBoxed},      GBoxed,         :boxed),
     (:GParam,     Ptr{GParamSpec},  Ptr{GParamSpec},:param),
@@ -41,14 +41,14 @@ const fundamental_types = (
     #(:GVariant,  Ptr{GVariant},    GVariant,       :variant),
     )
 # NOTE: in general do not cache ids, except for these fundamental values
-g_type_from_name(name::Symbol) = ccall((:g_type_from_name,libgobject),GType,(Ptr{Uint8},),name)
+g_type_from_name(name::Symbol) = ccall((:g_type_from_name,libgobject),GType,(Ptr{UInt8},),name)
 const fundamental_ids = tuple(GType[g_type_from_name(name) for (name,c,j,f) in fundamental_types]...)
 
 g_type(gtyp::GType) = gtyp
 let jtypes = Expr(:block, :( g_type(::Type{Void}) = $(g_type_from_name(:void)) ))
     for i = 1:length(fundamental_types)
         (name, ctype, juliatype, g_value_fn) = fundamental_types[i]
-        if juliatype !== None
+        if juliatype !== Union()
             push!(jtypes.args, :( g_type{T<:$juliatype}(::Type{T}) = convert(GType,$(fundamental_ids[i])) ))
         end
     end
@@ -63,7 +63,7 @@ G_OBJECT_CLASS_TYPE(w) = G_TYPE_FROM_CLASS(G_OBJECT_GET_CLASS(w))
 g_isa(gtyp::GType, is_a_type::GType) = ccall((:g_type_is_a,libgobject),Cint,(GType,GType),gtyp,is_a_type) != 0
 g_isa(gtyp, is_a_type) = g_isa(g_type(gtyp), g_type(is_a_type))
 g_type_parent(child::GType) = ccall((:g_type_parent, libgobject), GType, (GType,), child)
-g_type_name(g_type::GType) = symbol(bytestring(ccall((:g_type_name,libgobject),Ptr{Uint8},(GType,),g_type),false))
+g_type_name(g_type::GType) = symbol(bytestring(ccall((:g_type_name,libgobject),Ptr{UInt8},(GType,),g_type),false))
 
 g_type_test_flags(g_type::GType, flag) = ccall((:g_type_test_flags,libgobject), Bool, (GType, GEnum), g_type, flag)
 const G_TYPE_FLAG_CLASSED           = 1 << 0
@@ -90,10 +90,10 @@ const gtype_ifaces = Dict{Symbol,Type}()
 gtype_abstracts[:GObject] = GObject
 gtype_wrappers[:GObject] = GObjectLeaf
 
-let libs = Dict{String,Any}()
+let libs = Dict{AbstractString,Any}()
 global get_fn_ptr
 function get_fn_ptr(fnname, lib)
-    if !isa(lib,String)
+    if !isa(lib,AbstractString)
         lib = eval(current_module(), lib)
     end
     libptr = get(libs, lib, C_NULL)::Ptr{Void}
@@ -261,7 +261,7 @@ end
 
 
 macro quark_str(q)
-    :( ccall((:g_quark_from_string, libglib), Uint32, (Ptr{Uint8},), bytestring($q)) )
+    :( ccall((:g_quark_from_string, libglib), UInt32, (Ptr{UInt8},), bytestring($q)) )
 end
 
 unsafe_convert{T<:GBoxed}(::Type{Ptr{T}}, box::T) = convert(Ptr{T}, box.handle)
@@ -286,7 +286,7 @@ function convert{T<:GObject}(::Type{T}, ptr::Ptr{T})
     if hnd == C_NULL
         throw(UndefRefError())
     end
-    x = ccall((:g_object_get_qdata, libgobject), Ptr{GObject}, (Ptr{GObject},Uint32), hnd, jlref_quark::Uint32)
+    x = ccall((:g_object_get_qdata, libgobject), Ptr{GObject}, (Ptr{GObject},UInt32), hnd, jlref_quark::UInt32)
     if x != C_NULL
         return gobject_ref(unsafe_pointer_to_objref(x)::T)
     end
@@ -406,7 +406,7 @@ function gobject_ref{T<:GObject}(x::T)
             deref = cfunction(gc_unref, Void, (T,))
         end
         ccall((:g_object_set_qdata_full, libgobject), Void,
-            (Ptr{GObject}, Uint32, Any, Ptr{Void}), x, jlref_quark::Uint32, x,
+            (Ptr{GObject}, UInt32, Any, Ptr{Void}), x, jlref_quark::UInt32, x,
             deref) # add a circular reference to the Julia object in the GObject
         addref()
     elseif strong
@@ -431,7 +431,7 @@ end
 function gc_unref(x::GObject)
     # this strongly destroys and invalidates the object
     # it is intended to be called by GLib, not in user code function
-    ref = ccall((:g_object_get_qdata,libgobject),Ptr{Void},(Ptr{GObject},Uint32),x,jlref_quark::Uint32)
+    ref = ccall((:g_object_get_qdata,libgobject),Ptr{Void},(Ptr{GObject},UInt32),x,jlref_quark::UInt32)
     if ref != C_NULL && x !== unsafe_pointer_to_objref(ref)
         # We got called because we are no longer the default object for this handle, but we are still alive
         warn("Duplicate Julia object creation detected for GObject")
@@ -442,7 +442,7 @@ function gc_unref(x::GObject)
         end
         ccall((:g_object_weak_ref,libgobject),Void,(Ptr{GObject},Ptr{Void},Any),x,deref,x)
     else
-        ccall((:g_object_steal_qdata,libgobject),Any,(Ptr{GObject},Uint32),x,jlref_quark::Uint32)
+        ccall((:g_object_steal_qdata,libgobject),Any,(Ptr{GObject},UInt32),x,jlref_quark::UInt32)
         gc_unref_weak(x)
     end
     nothing

--- a/src/GLib/gvalues.jl
+++ b/src/GLib/gvalues.jl
@@ -54,7 +54,7 @@ function make_gvalue(pass_x,as_ctype,to_gtype,with_id,allow_reverse::Bool=true,f
         with_id = with_id::TupleType(Symbol,Any)
         with_id = :(ccall($(Expr(:tuple, Meta.quot(symbol(string(with_id[1],"_get_type"))), with_id[2])),GType,()))
     end
-    if pass_x !== Union()
+    if pass_x !== Union{}
         eval(current_module(),quote
             function Base.setindex!{T<:$pass_x}(v::GLib.GV, ::Type{T})
                 ccall((:g_value_init,GLib.libgobject),Void,(Ptr{GLib.GValue},Csize_t), v, $with_id)
@@ -79,7 +79,7 @@ function make_gvalue(pass_x,as_ctype,to_gtype,with_id,allow_reverse::Bool=true,f
     if to_gtype == :static_string
         to_gtype = :string
     end
-    if pass_x !== Union()
+    if pass_x !== Union{}
         eval(current_module(),quote
             function Base.getindex{T<:$pass_x}(v::GLib.GV,::Type{T})
                 x = ccall(($(string("g_value_get_",to_gtype)),GLib.libgobject),$as_ctype,(Ptr{GLib.GValue},), v)
@@ -97,7 +97,7 @@ function make_gvalue(pass_x,as_ctype,to_gtype,with_id,allow_reverse::Bool=true,f
             function(v::GLib.GV)
                 x = ccall(($(string("g_value_get_",to_gtype)),GLib.libgobject),$as_ctype,(Ptr{GLib.GValue},), v)
                 $(if to_gtype == :string; :(x = GLib.bytestring(x)) end)
-                $(if pass_x !== Union()
+                $(if pass_x !== Union{}
                     :(return Base.convert($pass_x,x))
                 else
                     :(return x)

--- a/src/GLib/gvalues.jl
+++ b/src/GLib/gvalues.jl
@@ -2,8 +2,8 @@
 
 immutable GValue
     g_type::GType
-    field2::Uint64
-    field3::Uint64
+    field2::UInt64
+    field3::UInt64
     GValue() = new(0,0,0)
 end
 typealias GV Union(Mutable{GValue}, Ptr{GValue})
@@ -54,7 +54,7 @@ function make_gvalue(pass_x,as_ctype,to_gtype,with_id,allow_reverse::Bool=true,f
         with_id = with_id::TupleType(Symbol,Any)
         with_id = :(ccall($(Expr(:tuple, Meta.quot(symbol(string(with_id[1],"_get_type"))), with_id[2])),GType,()))
     end
-    if pass_x !== None
+    if pass_x !== Union()
         eval(current_module(),quote
             function Base.setindex!{T<:$pass_x}(v::GLib.GV, ::Type{T})
                 ccall((:g_value_init,GLib.libgobject),Void,(Ptr{GLib.GValue},Csize_t), v, $with_id)
@@ -79,7 +79,7 @@ function make_gvalue(pass_x,as_ctype,to_gtype,with_id,allow_reverse::Bool=true,f
     if to_gtype == :static_string
         to_gtype = :string
     end
-    if pass_x !== None
+    if pass_x !== Union()
         eval(current_module(),quote
             function Base.getindex{T<:$pass_x}(v::GLib.GV,::Type{T})
                 x = ccall(($(string("g_value_get_",to_gtype)),GLib.libgobject),$as_ctype,(Ptr{GLib.GValue},), v)
@@ -97,7 +97,7 @@ function make_gvalue(pass_x,as_ctype,to_gtype,with_id,allow_reverse::Bool=true,f
             function(v::GLib.GV)
                 x = ccall(($(string("g_value_get_",to_gtype)),GLib.libgobject),$as_ctype,(Ptr{GLib.GValue},), v)
                 $(if to_gtype == :string; :(x = GLib.bytestring(x)) end)
-                $(if pass_x !== None
+                $(if pass_x !== Union()
                     :(return Base.convert($pass_x,x))
                 else
                     :(return x)
@@ -114,7 +114,7 @@ const fundamental_fns = tuple(Function[begin
         (name, ctype, juliatype, g_value_fn) = fundamental_types[i]
         make_gvalue(juliatype, ctype, g_value_fn, fundamental_ids[i], false, true)
     end for i in 1:length(fundamental_types)]...)
-make_gvalue(Symbol, Ptr{Uint8}, :static_string, :(g_type(String)), false)
+make_gvalue(Symbol, Ptr{UInt8}, :static_string, :(g_type(AbstractString)), false)
 make_gvalue(Type, GType, :gtype, (:g_gtype,:libgobject))
 make_gvalue(Ptr{GBoxed}, Ptr{GBoxed}, :gboxed, :(g_type(GBoxed)), false)
 
@@ -149,25 +149,25 @@ function getindex(gv::GV, ::Type{Any})
 end
 #end
 
-function getproperty{T}(w::GObject, name::StringLike, ::Type{T})
+function getproperty{T}(w::GObject, name::AbstractStringLike, ::Type{T})
     v = gvalue(T)
     ccall((:g_object_get_property,libgobject), Void,
-        (Ptr{GObject}, Ptr{Uint8}, Ptr{GValue}), w, bytestring(name), v)
+        (Ptr{GObject}, Ptr{UInt8}, Ptr{GValue}), w, bytestring(name), v)
     val = v[T]
     ccall((:g_value_unset,libgobject),Void,(Ptr{GValue},), v)
     return val
 end
 
-setproperty!{T}(w::GObject, name::StringLike, ::Type{T}, value) = setproperty!(w, name, convert(T,value))
-function setproperty!(w::GObject, name::StringLike, value)
+setproperty!{T}(w::GObject, name::AbstractStringLike, ::Type{T}, value) = setproperty!(w, name, convert(T,value))
+function setproperty!(w::GObject, name::AbstractStringLike, value)
     ccall((:g_object_set_property, libgobject), Void,
-        (Ptr{GObject}, Ptr{Uint8}, Ptr{GValue}), w, bytestring(name), gvalue(value))
+        (Ptr{GObject}, Ptr{UInt8}, Ptr{GValue}), w, bytestring(name), gvalue(value))
     w
 end
 
-@deprecate getindex(w::GObject, name::StringLike, T::Type) getproperty(w,name,T)
-@deprecate setindex!(w::GObject, value, name::StringLike, T::Type) setproperty!(w,name,T,value)
-@deprecate setindex!(w::GObject, value, name::StringLike) setproperty!(w,name,value)
+@deprecate getindex(w::GObject, name::AbstractStringLike, T::Type) getproperty(w,name,T)
+@deprecate setindex!(w::GObject, value, name::AbstractStringLike, T::Type) setproperty!(w,name,T,value)
+@deprecate setindex!(w::GObject, value, name::AbstractStringLike) setproperty!(w,name,value)
 
 
 function show(io::IO, w::GObject)
@@ -194,12 +194,12 @@ function show(io::IO, w::GObject)
         if (param.flags & READABLE) != 0 &&
            (param.flags & DEPRECATED) == 0 &&
            (ccall((:g_value_type_transformable,libgobject),Cint,
-                (Int,Int),param.value_type,g_type(String)) != 0)
+                (Int,Int),param.value_type,g_type(AbstractString)) != 0)
             ccall((:g_object_get_property,libgobject), Void,
-                (Ptr{GObject}, Ptr{Uint8}, Ptr{GValue}), w, param.name, v)
-            str = ccall((:g_value_get_string,libgobject),Ptr{Uint8},(Ptr{GValue},), v)
+                (Ptr{GObject}, Ptr{UInt8}, Ptr{GValue}), w, param.name, v)
+            str = ccall((:g_value_get_string,libgobject),Ptr{UInt8},(Ptr{GValue},), v)
             value = (str == C_NULL ? "NULL" : bytestring(str))
-            if param.value_type == g_type(String) && str != C_NULL
+            if param.value_type == g_type(AbstractString) && str != C_NULL
                 print(io,"=\"",value,'"')
             else
                 print(io,'=',value)
@@ -212,7 +212,7 @@ end
 
 #immutable GTypeQuery
 #  g_type::Int
-#  type_name::Ptr{Uint8}
+#  type_name::Ptr{UInt8}
 #  class_size::Cuint
 #  instance_size::Cuint
 #  GTypeQuery() = new(0,0,0,0)

--- a/src/Gtk.jl
+++ b/src/Gtk.jl
@@ -7,7 +7,7 @@ include("GLib/GLib.jl")
 using .GLib
 using .GLib.MutableTypes
 importall .GLib.Compat
-import .GLib: setproperty!, getproperty, StringLike, bytestring
+import .GLib: setproperty!, getproperty, AbstractStringLike, bytestring
 import .GLib:
     signal_connect, signal_handler_disconnect,
     signal_handler_block, signal_handler_unblock,

--- a/src/application.jl
+++ b/src/application.jl
@@ -1,6 +1,6 @@
 if gtk_version == 3
-GtkApplicationLeaf(id::String, flags) = GtkApplicationLeaf(
-    ccall((:gtk_application_new, libgtk), Ptr{GObject}, (Ptr{Uint8}, Cuint), bytestring(id), flags) )
+GtkApplicationLeaf(id::AbstractString, flags) = GtkApplicationLeaf(
+    ccall((:gtk_application_new, libgtk), Ptr{GObject}, (Ptr{UInt8}, Cuint), bytestring(id), flags) )
 
 function push!(app::GtkApplication, win::GtkWindow)
     ccall((:gtk_application_add_window, libgtk), Void, (Ptr{GObject}, Ptr{GObject}), app, win)

--- a/src/base.jl
+++ b/src/base.jl
@@ -1,4 +1,4 @@
-unsafe_convert(::Type{Ptr{GObject}},w::StringLike) = unsafe_convert(Ptr{GObject},GtkLabelLeaf(w))
+unsafe_convert(::Type{Ptr{GObject}},w::AbstractStringLike) = unsafe_convert(Ptr{GObject},GtkLabelLeaf(w))
 
 destroy(w::GtkWidget) = ccall((:gtk_widget_destroy,libgtk), Void, (Ptr{GObject},), w)
 parent(w::GtkWidget) = convert(GtkWidget, ccall((:gtk_widget_get_parent,libgtk), Ptr{GObject}, (Ptr{GObject},), w))
@@ -37,20 +37,20 @@ showall(w::GtkWidget) = (ccall((:gtk_widget_show_all,libgtk),Void,(Ptr{GObject},
 modifyfont(w::GtkWidget, font_desc::Ptr{Void}) =
    ccall((:gtk_widget_modify_font,libgtk),Void,(Ptr{GObject},Ptr{Void}),w,font_desc)
 
-function getproperty{T}(w::GtkContainer, name::StringLike, child::GtkWidget, ::Type{T})
+function getproperty{T}(w::GtkContainer, name::AbstractStringLike, child::GtkWidget, ::Type{T})
     v = gvalue(T)
     ccall((:gtk_container_child_get_property,libgtk), Void,
-        (Ptr{GObject}, Ptr{GObject}, Ptr{Uint8}, Ptr{GValue}), w, child, bytestring(name), v)
+        (Ptr{GObject}, Ptr{GObject}, Ptr{UInt8}, Ptr{GValue}), w, child, bytestring(name), v)
     val = v[T]
     ccall((:g_value_unset,libgobject),Void,(Ptr{GValue},), v)
     return val
 end
 
 #property(w::GtkContainer, value, child::GtkWidget, ::Type{T}) = error("missing Gtk property-name to set")
-setproperty!{T}(w::GtkContainer, name::StringLike, child::GtkWidget, ::Type{T}, value) = setproperty!(w, name, child, convert(T,value))
-function setproperty!(w::GtkContainer, name::StringLike, child::GtkWidget, value)
+setproperty!{T}(w::GtkContainer, name::AbstractStringLike, child::GtkWidget, ::Type{T}, value) = setproperty!(w, name, child, convert(T,value))
+function setproperty!(w::GtkContainer, name::AbstractStringLike, child::GtkWidget, value)
     ccall((:gtk_container_child_set_property,libgtk), Void,
-        (Ptr{GObject}, Ptr{GObject}, Ptr{Uint8}, Ptr{GValue}), w, child, bytestring(name), gvalue(value))
+        (Ptr{GObject}, Ptr{GObject}, Ptr{UInt8}, Ptr{GValue}), w, child, bytestring(name), gvalue(value))
     w
 end
 
@@ -96,17 +96,17 @@ function _guarded(ex, retval)
 end
 
 
-@deprecate getindex(w::GtkContainer, child::GtkWidget, name::StringLike, T::Type) getproperty(w,name,child,T)
-@deprecate setindex!(w::GtkContainer, value, child::GtkWidget, name::StringLike, T::Type) setproperty!(w,name,child,T,value)
-@deprecate setindex!(w::GtkContainer, value, child::GtkWidget, name::StringLike) setproperty!(w,name,child,value)
+@deprecate getindex(w::GtkContainer, child::GtkWidget, name::AbstractStringLike, T::Type) getproperty(w,name,child,T)
+@deprecate setindex!(w::GtkContainer, value, child::GtkWidget, name::AbstractStringLike, T::Type) setproperty!(w,name,child,T,value)
+@deprecate setindex!(w::GtkContainer, value, child::GtkWidget, name::AbstractStringLike) setproperty!(w,name,child,value)
 
 GtkAccelGroupLeaf() = GtkAccelGroupLeaf(
     ccall((:gtk_accel_group_new,libgtk),Ptr{GObject},()))
 
-function push!(w::GtkWidget, accel_signal::StringLike, accel_group::GtkAccelGroup,
+function push!(w::GtkWidget, accel_signal::AbstractStringLike, accel_group::GtkAccelGroup,
                accel_key::Integer, accel_mods::Integer, accel_flags::Integer)
     ccall((:gtk_widget_add_accelerator,libgtk), Void,
-         (Ptr{GObject}, Ptr{Uint8}, Ptr{GObject}, Cuint, Cint, Cint),
+         (Ptr{GObject}, Ptr{UInt8}, Ptr{GObject}, Cuint, Cint, Cint),
           w, bytestring(accel_signal), accel_group, accel_key, accel_mods, accel_flags)
     w
 end

--- a/src/builder.jl
+++ b/src/builder.jl
@@ -12,21 +12,21 @@ function push!(builder::GtkBuilder;buffer=nothing,filename=nothing,resource=noth
     if buffer !== nothing
         GError() do error_check
           ret = ccall((:gtk_builder_add_from_string ,libgtk), Cuint,
-            (Ptr{GObject}, Ptr{Uint8}, Culong, Ptr{Ptr{GError}}),
+            (Ptr{GObject}, Ptr{UInt8}, Culong, Ptr{Ptr{GError}}),
             builder, bytestring(buffer), -1, error_check)
           return ret != 0
         end
     elseif filename !== nothing
         GError() do error_check
           ret = ccall((:gtk_builder_add_from_file ,libgtk), Cuint,
-            (Ptr{GObject}, Ptr{Uint8}, Ptr{Ptr{GError}}),
+            (Ptr{GObject}, Ptr{UInt8}, Ptr{Ptr{GError}}),
             builder, bytestring(filename), error_check)
           return ret != 0
         end
     elseif resource !== nothing
         GError() do error_check
           ret = ccall((:gtk_builder_add_from_resource ,libgtk), Cuint,
-            (Ptr{GObject}, Ptr{Uint8}, Ptr{Ptr{GError}}),
+            (Ptr{GObject}, Ptr{UInt8}, Ptr{Ptr{GError}}),
             builder, bytestring(resource), error_check)
           return ret != 0
         end

--- a/src/buttons.jl
+++ b/src/buttons.jl
@@ -14,19 +14,19 @@
 #GtkLockButton — A widget to unlock or lock privileged operations
 
 GtkButtonLeaf() = GtkButtonLeaf(ccall((:gtk_button_new,libgtk),Ptr{GObject},()))
-GtkButtonLeaf(title::String) =
+GtkButtonLeaf(title::AbstractString) =
     GtkButtonLeaf(ccall((:gtk_button_new_with_mnemonic,libgtk),Ptr{GObject},
-        (Ptr{Uint8},), bytestring(title)))
+        (Ptr{UInt8},), bytestring(title)))
 
 GtkCheckButtonLeaf() = GtkCheckButtonLeaf(ccall((:gtk_check_button_new,libgtk),Ptr{GObject},()))
-GtkCheckButtonLeaf(title::String) =
+GtkCheckButtonLeaf(title::AbstractString) =
     GtkCheckButtonLeaf(ccall((:gtk_check_button_new_with_mnemonic,libgtk),Ptr{GObject},
-        (Ptr{Uint8},), bytestring(title)))
+        (Ptr{UInt8},), bytestring(title)))
 
 GtkToggleButtonLeaf() = GtkToggleButtonLeaf(ccall((:gtk_toggle_button_new,libgtk),Ptr{GObject},()))
-GtkToggleButtonLeaf(title::String) =
+GtkToggleButtonLeaf(title::AbstractString) =
     GtkToggleButtonLeaf(ccall((:gtk_toggle_button_new_with_mnemonic,libgtk),Ptr{GObject},
-        (Ptr{Uint8},), bytestring(title)))
+        (Ptr{UInt8},), bytestring(title)))
 
 if gtk_version >= 3
     GtkSwitchLeaf() = GtkSwitchLeaf(ccall((:gtk_switch_new,libgtk),Ptr{GObject},()))
@@ -40,18 +40,18 @@ end
 GtkRadioButtonLeaf(group::Ptr{Void}=C_NULL) =
     GtkRadioButtonLeaf(ccall((:gtk_radio_button_new,libgtk),Ptr{GObject},
         (Ptr{Void},),group))
-GtkRadioButtonLeaf(group::Ptr{Void},label::String) =
+GtkRadioButtonLeaf(group::Ptr{Void},label::AbstractString) =
     GtkRadioButtonLeaf(ccall((:gtk_radio_button_new_with_mnemonic,libgtk),Ptr{GObject},
-        (Ptr{Void},Ptr{Uint8}),group,bytestring(label)))
-GtkRadioButtonLeaf(label::String) =
+        (Ptr{Void},Ptr{UInt8}),group,bytestring(label)))
+GtkRadioButtonLeaf(label::AbstractString) =
     GtkRadioButtonLeaf(ccall((:gtk_radio_button_new_with_mnemonic,libgtk),Ptr{GObject},
-        (Ptr{Void},Ptr{Uint8}),C_NULL,bytestring(label)))
+        (Ptr{Void},Ptr{UInt8}),C_NULL,bytestring(label)))
 GtkRadioButtonLeaf(group::GtkRadioButton) =
     GtkRadioButtonLeaf(ccall((:gtk_radio_button_new_from_widget,libgtk),Ptr{GObject},
         (Ptr{GObject},),group))
-GtkRadioButtonLeaf(group::GtkRadioButton,label::String) =
+GtkRadioButtonLeaf(group::GtkRadioButton,label::AbstractString) =
     GtkRadioButtonLeaf(ccall((:gtk_radio_button_new_with_mnemonic_from_widget,libgtk),Ptr{GObject},
-        (Ptr{GObject},Ptr{Uint8}),group,bytestring(label)))
+        (Ptr{GObject},Ptr{UInt8}),group,bytestring(label)))
 GtkRadioButtonLeaf(group::GtkRadioButton,child::GtkWidget,vargs...) =
     push!(GtkRadioButtonLeaf(group,vargs...), child)
 
@@ -93,7 +93,7 @@ function push!(grp::GtkRadioButtonGroup,e::GtkRadioButton)
     push!(grp.handle, e)
     grp
 end
-function push!(grp::GtkRadioButtonGroup,label,active::Union(Bool,Nothing)=nothing)
+function push!(grp::GtkRadioButtonGroup,label,active::Union(Bool,Void)=nothing)
     if isdefined(grp,:anchor)
         e = GtkRadioButtonLeaf(grp.anchor, label)
     else
@@ -119,7 +119,7 @@ done(w::GtkRadioButtonGroup,s) = done(s,s)
 length(w::GtkRadioButtonGroup) = length(start(w))
 getindex!(w::GtkRadioButtonGroup, i::Integer) = convert(GtkRadioButton,start(w)[i])
 isempty(grp::GtkRadioButtonGroup) = !isdefined(grp,:anchor)
-function getproperty(grp::GtkRadioButtonGroup,name::StringLike)
+function getproperty(grp::GtkRadioButtonGroup,name::AbstractStringLike)
     k = symbol(name)
     if k == :active
         for b in grp
@@ -138,18 +138,18 @@ function gtk_toggle_button_set_active(b::GtkWidget, active::Bool)
     b
 end
 
-GtkLinkButtonLeaf(uri::String) =
+GtkLinkButtonLeaf(uri::AbstractString) =
     GtkLinkButtonLeaf(ccall((:gtk_link_button_new,libgtk),Ptr{GObject},
-        (Ptr{Uint8},),bytestring(uri)))
-GtkLinkButtonLeaf(uri::String,label::String) =
+        (Ptr{UInt8},),bytestring(uri)))
+GtkLinkButtonLeaf(uri::AbstractString,label::AbstractString) =
     GtkLinkButtonLeaf(ccall((:gtk_link_button_new_with_label,libgtk),Ptr{GObject},
-        (Ptr{Uint8},Ptr{Uint8}),bytestring(uri),bytestring(label)))
-function GtkLinkButtonLeaf(uri::String,label::String,visited::Bool)
+        (Ptr{UInt8},Ptr{UInt8}),bytestring(uri),bytestring(label)))
+function GtkLinkButtonLeaf(uri::AbstractString,label::AbstractString,visited::Bool)
     b = GtkLinkButtonLeaf(uri,label)
     ccall((:gtk_link_button_set_visited,libgtk),Void,(Ptr{GObject},Cint),b,visited)
     b
 end
-function GtkLinkButtonLeaf(uri::String,visited::Bool)
+function GtkLinkButtonLeaf(uri::AbstractString,visited::Bool)
     b = GtkLinkButtonLeaf(uri)
     ccall((:gtk_link_button_set_visited,libgtk),Void,(Ptr{GObject},Cint),b,visited)
     b

--- a/src/cairo.jl
+++ b/src/cairo.jl
@@ -4,8 +4,8 @@ type GtkCanvas <: GtkDrawingArea # NOT an @GType
     is_realized::Bool
     is_sized::Bool
     mouse::MouseHandler
-    resize::Union(Function,Nothing)
-    draw::Union(Function,Nothing)
+    resize::Union(Function,Void)
+    draw::Union(Function,Void)
     back::CairoSurface   # backing store
     backcc::CairoContext
 

--- a/src/container.jl
+++ b/src/container.jl
@@ -18,7 +18,7 @@ function append!(w::GtkContainer, children)
     end
     w
 end
-Base.|>(parent::GtkContainer, child::Union(GObject,String)) = push!(parent, child)
+Base.|>(parent::GtkContainer, child::Union(GObject,AbstractString)) = push!(parent, child)
 
 start(w::GtkContainer) = glist_iter(ccall((:gtk_container_get_children,libgtk), Ptr{_GList{GObject}}, (Ptr{GObject},), w))
 next(w::GtkContainer, list) = next(list[1],list)

--- a/src/displays.jl
+++ b/src/displays.jl
@@ -8,14 +8,14 @@
 #GtkSpinner — Show a spinner animation
 
 immutable RGB
-    r::Uint8; g::Uint8; b::Uint8
+    r::UInt8; g::UInt8; b::UInt8
     RGB(r,g,b) = new(r,g,b)
 end
 convert(::Type{RGB},x::Unsigned) = RGB(uint8(x),uint8(x>>8),uint8(x>>16))
 convert{U<:Unsigned}(::Type{U},x::RGB) = convert(U,(x.r)|(x.g>>8)|(x.b>>16))
 
 immutable RGBA
-    r::Uint8; g::Uint8; b::Uint8; a::Uint8
+    r::UInt8; g::UInt8; b::UInt8; a::UInt8
     RGBA(r,g,b) = new(r,g,b)
 end
 convert(::Type{RGBA},x::Unsigned) = RGBA(uint8(x),uint8(x>>8),uint8(x>>16),uint8(x>>24))
@@ -167,20 +167,20 @@ function GdkPixbufLeaf(;stream=nothing,resource_path=nothing,filename=nothing,xp
     elseif resource_path !== nothing
         GError() do error_check
             if width == -1 && height == -1
-                pixbuf = ccall((:gdk_pixbuf_new_from_resource,libgdk_pixbuf),Ptr{GObject},(Ptr{Uint8},Ptr{Ptr{GError}}),bytestring(resource_path),error_check)
+                pixbuf = ccall((:gdk_pixbuf_new_from_resource,libgdk_pixbuf),Ptr{GObject},(Ptr{UInt8},Ptr{Ptr{GError}}),bytestring(resource_path),error_check)
             else
                 pixbuf = ccall((:gdk_pixbuf_new_from_resource_at_scale,libgdk_pixbuf),Ptr{GObject},
-                    (Ptr{Uint8},Cint,Cint,Cint,Ptr{Ptr{GError}}),bytestring(resource_path),width,height,preserve_aspect_ratio,error_check)
+                    (Ptr{UInt8},Cint,Cint,Cint,Ptr{Ptr{GError}}),bytestring(resource_path),width,height,preserve_aspect_ratio,error_check)
             end
             return pixbuf !== C_NULL
         end
     elseif filename !== nothing
         GError() do error_check
             if width == -1 && height == -1
-                pixbuf = ccall((:gdk_pixbuf_new_from_file,libgdk_pixbuf),Ptr{GObject},(Ptr{Uint8},Ptr{Ptr{GError}}),bytestring(filename),error_check)
+                pixbuf = ccall((:gdk_pixbuf_new_from_file,libgdk_pixbuf),Ptr{GObject},(Ptr{UInt8},Ptr{Ptr{GError}}),bytestring(filename),error_check)
             else
                 pixbuf = ccall((:gdk_pixbuf_new_from_file_at_scale,libgdk_pixbuf),Ptr{GObject},
-                    (Ptr{Uint8},Cint,Cint,Cint,Ptr{Ptr{GError}}),bytestring(filename),width,height,preserve_aspect_ratio,error_check)
+                    (Ptr{UInt8},Cint,Cint,Cint,Ptr{Ptr{GError}}),bytestring(filename),width,height,preserve_aspect_ratio,error_check)
             end
             return pixbuf !== C_NULL
         end
@@ -261,7 +261,7 @@ Base.fill!(img::GdkPixbuf,pix) = fill!(convert(MatrixStrided,img),pix)
 #TODO: image transformations, rotations, compositing
 
 GtkImageLeaf(pixbuf::GdkPixbuf) = GtkImageLeaf(ccall((:gtk_image_new_from_pixbuf,libgtk),Ptr{GObject},(Ptr{GObject},),pixbuf))
-GtkImageLeaf(filename::String) = GtkImageLeaf(ccall((:gtk_image_new_from_file,libgtk),Ptr{GObject},(Ptr{Uint8},),bytestring(filename)))
+GtkImageLeaf(filename::AbstractString) = GtkImageLeaf(ccall((:gtk_image_new_from_file,libgtk),Ptr{GObject},(Ptr{UInt8},),bytestring(filename)))
 
 function GtkImageLeaf(;resource_path=nothing,filename=nothing,icon_name=nothing,stock_id=nothing,size::Symbol=:INVALID)
     source_count = (resource_path!==nothing) + (filename!==nothing) + (icon_name!==nothing) + (stock_id!==nothing)
@@ -269,13 +269,13 @@ function GtkImageLeaf(;resource_path=nothing,filename=nothing,icon_name=nothing,
         "GdkPixbuf must have at most one resource_path, filename, stock_id, or icon_name argument")
     local img::Ptr{GObject}
     if resource_path !== nothing
-        img = ccall((:gtk_image_new_from_resource,libgtk),Ptr{GObject},(Ptr{Uint8},),bytestring(resource_path))
+        img = ccall((:gtk_image_new_from_resource,libgtk),Ptr{GObject},(Ptr{UInt8},),bytestring(resource_path))
     elseif filename !== nothing
-        img = ccall((:gtk_image_new_from_file,libgtk),Ptr{GObject},(Ptr{Uint8},),bytestring(filename))
+        img = ccall((:gtk_image_new_from_file,libgtk),Ptr{GObject},(Ptr{UInt8},),bytestring(filename))
     elseif icon_name !== nothing
-        img = ccall((:gtk_image_new_from_icon_name,libgtk),Ptr{GObject},(Ptr{Uint8},Cint),bytestring(icon_name),GtkIconSize.(size))
+        img = ccall((:gtk_image_new_from_icon_name,libgtk),Ptr{GObject},(Ptr{UInt8},Cint),bytestring(icon_name),GtkIconSize.(size))
     elseif stock_id !== nothing
-        img = ccall((:gtk_image_new_from_stock,libgtk),Ptr{GObject},(Ptr{Uint8},Cint),bytestring(stock_id),GtkIconSize.(size))
+        img = ccall((:gtk_image_new_from_stock,libgtk),Ptr{GObject},(Ptr{UInt8},Cint),bytestring(stock_id),GtkIconSize.(size))
     else
         img = ccall((:gtk_image_new,libgtk),Ptr{GObject},())
     end
@@ -294,11 +294,11 @@ stop(spinner::GtkSpinner) = ccall((:gtk_spinner_stop,libgtk),Void,(Ptr{GObject},
 
 GtkStatusbarLeaf() = GtkStatusbarLeaf(ccall((:gtk_statusbar_new,libgtk),Ptr{GObject},()))
 context_id(status::GtkStatusbar,source) =
-    ccall((:gtk_statusbar_get_context_id,libgtk),Cuint,(Ptr{GObject},Ptr{Uint8}),
+    ccall((:gtk_statusbar_get_context_id,libgtk),Cuint,(Ptr{GObject},Ptr{UInt8}),
         status,bytestring(source))
 context_id(status::GtkStatusbar,source::Integer) = source
 push!(status::GtkStatusbar,context,text) =
-    (ccall((:gtk_statusbar_push,libgtk),Cuint,(Ptr{GObject},Cuint,Ptr{Uint8}),
+    (ccall((:gtk_statusbar_push,libgtk),Cuint,(Ptr{GObject},Cuint,Ptr{UInt8}),
         status,context_id(status,context),bytestring(text)); status)
 pop!(status::GtkStatusbar,context) =
     ccall((:gtk_statusbar_pop,libgtk),Ptr{GObject},(Ptr{GObject},Cuint),

--- a/src/events.jl
+++ b/src/events.jl
@@ -9,7 +9,7 @@ end
 function __init__()
     GError() do error_check
         ccall((:gtk_init_with_args,libgtk), Bool,
-            (Ptr{Void}, Ptr{Void}, Ptr{Uint8}, Ptr{Void}, Ptr{Uint8}, Ptr{GError}),
+            (Ptr{Void}, Ptr{Void}, Ptr{UInt8}, Ptr{Void}, Ptr{UInt8}, Ptr{GError}),
             C_NULL, C_NULL, "Julia Gtk Bindings", C_NULL, C_NULL, error_check)
     end
 
@@ -26,7 +26,7 @@ add_events(widget::GtkWidget, mask::Integer) = ccall((:gtk_widget_add_events,lib
 # widget[:event] = function(ptr, obj)
 #    stuff
 # end
-#function setindex!(w::GObject,cb::Function,sig::StringLike,vargs...)
+#function setindex!(w::GObject,cb::Function,sig::AbstractStringLike,vargs...)
 #    signal_connect(cb,w,sig,vargs...)
 #end
 
@@ -51,8 +51,8 @@ end
 type Gtk_signal_motion{T}
     closure::T
     callback::Ptr{Void}
-    include::Uint32
-    exclude::Uint32
+    include::UInt32
+    exclude::UInt32
 end
 function notify_motion{T}(p::Ptr{GObject}, eventp::Ptr{GdkEventMotion}, closure::Gtk_signal_motion{T})
     event = unsafe_load(eventp)

--- a/src/gdk.jl
+++ b/src/gdk.jl
@@ -102,12 +102,12 @@ immutable GdkEventButton <: GdkEvent
     event_type::GEnum
     gdk_window::Ptr{Void}
     send_event::Int8
-    time::Uint32
+    time::UInt32
     x::Float64
     y::Float64
     axes::Ptr{Float64}
-    state::Uint32
-    button::Uint32
+    state::UInt32
+    button::UInt32
     gdk_device::Ptr{Void}
     x_root::Float64
     y_root::Float64
@@ -117,10 +117,10 @@ immutable GdkEventScroll <: GdkEvent
     event_type::GEnum
     gdk_window::Ptr{Void}
     send_event::Int8
-    time::Uint32
+    time::UInt32
     x::Float64
     y::Float64
-    state::Uint32
+    state::UInt32
     direction::GEnum
     gdk_device::Ptr{Void}
     x_root::Float64
@@ -133,14 +133,14 @@ immutable GdkEventKey <: GdkEvent
     event_type::GEnum
     gdk_window::Ptr{Void}
     send_event::Int8
-    time::Uint32
-    state::Uint32
-    keyval::Uint32
+    time::UInt32
+    state::UInt32
+    keyval::UInt32
     length::Int32
-    string::Ptr{Uint8}
-    hardware_keycode::Uint16
-    group::Uint8
-    flags::Uint32
+    string::Ptr{UInt8}
+    hardware_keycode::UInt16
+    group::UInt8
+    flags::UInt32
 end
 
 is_modifier(evt::GdkEventKey) = (evt.flags & 0x0001) > 0
@@ -149,11 +149,11 @@ immutable GdkEventMotion <: GdkEvent
   event_type::GEnum
   gdk_window::Ptr{Void}
   send_event::Int8
-  time::Uint32
+  time::UInt32
   x::Float64
   y::Float64
   axes::Ptr{Float64}
-  state::Uint32
+  state::UInt32
   is_hint::Int16
   gdk_device::Ptr{Void}
   x_root::Float64
@@ -165,7 +165,7 @@ immutable GdkEventCrossing <: GdkEvent
   gdk_window::Ptr{Void}
   send_event::Int8
   gdk_subwindow::Ptr{Void}
-  time::Uint32
+  time::UInt32
   x::Float64
   y::Float64
   x_root::Float64
@@ -173,9 +173,9 @@ immutable GdkEventCrossing <: GdkEvent
   mode::GEnum
   detail::GEnum
   focus::Cint
-  state::Uint32
+  state::UInt32
 end
 
-keyval(name::String) =
-  ccall((:gdk_keyval_from_name,libgdk),Cuint,(Ptr{Uint8},),bytestring(name))
+keyval(name::AbstractString) =
+  ccall((:gdk_keyval_from_name,libgdk),Cuint,(Ptr{UInt8},),bytestring(name))
 

--- a/src/gio.jl
+++ b/src/gio.jl
@@ -1,6 +1,6 @@
 if gtk_version == 3
 run(app::GApplication) = GLib.g_sigatom() do
-    ccall((:g_application_run,libgio),Cint, (Ptr{GObject},Cint, Ptr{Ptr{Uint8}}), app, 0, C_NULL)
+    ccall((:g_application_run,libgio),Cint, (Ptr{GObject},Cint, Ptr{Ptr{UInt8}}), app, 0, C_NULL)
 end
 
 function register(app::GApplication)

--- a/src/input.jl
+++ b/src/input.jl
@@ -29,15 +29,15 @@ else
         end)
 end
 GtkScaleLeaf(vertical::Bool,scale::Range) = GtkScaleLeaf(vertical,minimum(scale),maximum(scale),step(scale))
-function push!(scale::GtkScale, value, position::Symbol, markup::String)
+function push!(scale::GtkScale, value, position::Symbol, markup::AbstractString)
     ccall((:gtk_scale_add_mark,libgtk),Void,
-        (Ptr{GObject},Cdouble,GEnum,Ptr{Uint8}),
+        (Ptr{GObject},Cdouble,GEnum,Ptr{UInt8}),
         scale,value,GtkPositionType.(position),bytestring(markup))
     scale
 end
 function push!(scale::GtkScale, value, position::Symbol)
     ccall((:gtk_scale_add_mark,libgtk),Void,
-        (Ptr{GObject},Cdouble,GEnum,Ptr{Uint8}),
+        (Ptr{GObject},Cdouble,GEnum,Ptr{UInt8}),
         scale,value,GtkPositionType.(position),C_NULL)
     scale
 end

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -83,18 +83,18 @@ GtkAlignmentLeaf(xalign, yalign, xscale, yscale) = # % of available space, 0<=a<
         (Cfloat, Cfloat, Cfloat, Cfloat), xalign, yalign, xscale, yscale))
 
 ### GtkFrame — A bin with a decorative frame and optional label
-GtkFrameLeaf(label::StringLike) = GtkFrameLeaf(ccall((:gtk_frame_new, libgtk), Ptr{GObject},
-        (Ptr{Uint8},), bytestring(label)))
+GtkFrameLeaf(label::AbstractStringLike) = GtkFrameLeaf(ccall((:gtk_frame_new, libgtk), Ptr{GObject},
+        (Ptr{UInt8},), bytestring(label)))
 GtkFrameLeaf() = GtkFrameLeaf(ccall((:gtk_frame_new, libgtk), Ptr{GObject},
-        (Ptr{Uint8},), C_NULL))
+        (Ptr{UInt8},), C_NULL))
 
 ### GtkAspectFrame
 GtkAspectFrameLeaf(label, xalign, yalign, ratio) = # % of available space, 0<=a<=1
     GtkAspectFrameLeaf(ccall((:gtk_aspect_frame_new, libgtk), Ptr{GObject},
-        (Ptr{Uint8}, Cfloat, Cfloat, Cfloat, Cint), bytestring(label), xalign, yalign, ratio, false))
+        (Ptr{UInt8}, Cfloat, Cfloat, Cfloat, Cint), bytestring(label), xalign, yalign, ratio, false))
 GtkAspectFrameLeaf(label, xalign, yalign) = # % of available space, 0<=a<=1. Uses the aspect ratio of the child
     GtkAspectFrameLeaf(ccall((:gtk_aspect_frame_new, libgtk), Ptr{GObject},
-        (Ptr{Uint8}, Cfloat, Cfloat, Cfloat, Cint), bytestring(label), xalign, yalign, 1., true))
+        (Ptr{UInt8}, Cfloat, Cfloat, Cfloat, Cint), bytestring(label), xalign, yalign, 1., true))
 
 ### GtkBox
 if gtk_version == 3
@@ -199,25 +199,25 @@ width(layout::GtkLayout) = size(layout)[1]
 height(layout::GtkLayout) = size(layout)[2]
 
 ### GtkExpander
-GtkExpanderLeaf(title::StringLike) =
+GtkExpanderLeaf(title::AbstractStringLike) =
     GtkExpanderLeaf(ccall((:gtk_expander_new, libgtk), Ptr{GObject},
-        (Ptr{Uint8},), bytestring(title)))
+        (Ptr{UInt8},), bytestring(title)))
 
 ### GtkNotebook
 GtkNotebookLeaf() = GtkNotebookLeaf(ccall((:gtk_notebook_new, libgtk), Ptr{GObject},()))
-function insert!(w::GtkNotebook, position::Integer, x::Union(GtkWidget,StringLike), label::Union(GtkWidget,StringLike))
+function insert!(w::GtkNotebook, position::Integer, x::Union(GtkWidget,AbstractStringLike), label::Union(GtkWidget,AbstractStringLike))
     ccall((:gtk_notebook_insert_page,libgtk), Cint,
         (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}, Cint),
         w, x, label, position-1)+1
     w
 end
-function unshift!(w::GtkNotebook, x::Union(GtkWidget,StringLike), label::Union(GtkWidget,StringLike))
+function unshift!(w::GtkNotebook, x::Union(GtkWidget,AbstractStringLike), label::Union(GtkWidget,AbstractStringLike))
     ccall((:gtk_notebook_prepend_page,libgtk), Cint,
         (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}),
         w, x, label)+1
     w
 end
-function push!(w::GtkNotebook, x::Union(GtkWidget,StringLike), label::Union(GtkWidget,StringLike))
+function push!(w::GtkNotebook, x::Union(GtkWidget,AbstractStringLike), label::Union(GtkWidget,AbstractStringLike))
     ccall((:gtk_notebook_append_page,libgtk), Cint,
         (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}),
         w, x, label)+1
@@ -235,7 +235,7 @@ pagenumber(w::GtkNotebook, child::GtkWidget) =
 ### GtkOverlay
 if gtk_version == 3
     GtkOverlayLeaf() = GtkOverlayLeaf(ccall((:gtk_overlay_new, libgtk), Ptr{GObject},
-        (Ptr{Uint8},), bytestring(title)))
+        (Ptr{UInt8},), bytestring(title)))
     GtkOverlayLeaf(w::GtkWidget) = invoke(push!, (GtkContainer,), GtkOverlayLeaf(), w)
     function push!(w::GtkOverlay, x::GtkWidget)
         ccall((:gtk_overlay_add_overlay,libgtk), Cint,

--- a/src/lists.jl
+++ b/src/lists.jl
@@ -34,20 +34,20 @@ GtkComboBoxTextLeaf(with_entry::Bool=false) = GtkComboBoxTextLeaf(
         else
             ccall((:gtk_combo_box_text_new,libgtk),Ptr{GObject},())
         end)
-push!(cb::GtkComboBoxText,text::String) =
-    (ccall((:gtk_combo_box_text_append_text,libgtk),Void,(Ptr{GObject},Ptr{Uint8}),cb,bytestring(text)); cb)
-unshift!(cb::GtkComboBoxText,text::String) =
-    (ccall((:gtk_combo_box_text_prepend_text,libgtk),Void,(Ptr{GObject},Ptr{Uint8}),cb,bytestring(text)); cb)
-insert!(cb::GtkComboBoxText,i::Integer,text::String) =
-    (ccall((:gtk_combo_box_text_insert_text,libgtk),Void,(Ptr{GObject},Cint,Ptr{Uint8}),cb,i-1,bytestring(text)); cb)
+push!(cb::GtkComboBoxText,text::AbstractString) =
+    (ccall((:gtk_combo_box_text_append_text,libgtk),Void,(Ptr{GObject},Ptr{UInt8}),cb,bytestring(text)); cb)
+unshift!(cb::GtkComboBoxText,text::AbstractString) =
+    (ccall((:gtk_combo_box_text_prepend_text,libgtk),Void,(Ptr{GObject},Ptr{UInt8}),cb,bytestring(text)); cb)
+insert!(cb::GtkComboBoxText,i::Integer,text::AbstractString) =
+    (ccall((:gtk_combo_box_text_insert_text,libgtk),Void,(Ptr{GObject},Cint,Ptr{UInt8}),cb,i-1,bytestring(text)); cb)
 
 if gtk_version == 3
-    push!(cb::GtkComboBoxText,id::TupleType(String,Symbol),text::String) =
-        (ccall((:gtk_combo_box_text_append,libgtk),Void,(Ptr{GObject},Ptr{Uint8},Ptr{Uint8}),cb,id,bytestring(text)); cb)
-    unshift!(cb::GtkComboBoxText,id::TupleType(String,Symbol),text::String) =
-        (ccall((:gtk_combo_box_text_prepend,libgtk),Void,(Ptr{GObject},Ptr{Uint8},Ptr{Uint8}),cb,id,bytestring(text)); cb)
-    insert!(cb::GtkComboBoxText,i::Integer,id::TupleType(String,Symbol),text::String) =
-        (ccall((:gtk_combo_box_text_insert_text,libgtk),Void,(Ptr{GObject},Cint,Ptr{Uint8}),cb,i-1,id,bytestring(text)); cb)
+    push!(cb::GtkComboBoxText,id::TupleType(AbstractString,Symbol),text::AbstractString) =
+        (ccall((:gtk_combo_box_text_append,libgtk),Void,(Ptr{GObject},Ptr{UInt8},Ptr{UInt8}),cb,id,bytestring(text)); cb)
+    unshift!(cb::GtkComboBoxText,id::TupleType(AbstractString,Symbol),text::AbstractString) =
+        (ccall((:gtk_combo_box_text_prepend,libgtk),Void,(Ptr{GObject},Ptr{UInt8},Ptr{UInt8}),cb,id,bytestring(text)); cb)
+    insert!(cb::GtkComboBoxText,i::Integer,id::TupleType(AbstractString,Symbol),text::AbstractString) =
+        (ccall((:gtk_combo_box_text_insert_text,libgtk),Void,(Ptr{GObject},Cint,Ptr{UInt8}),cb,i-1,id,bytestring(text)); cb)
 end
 
 delete!(cb::GtkComboBoxText,i::Integer) =
@@ -94,13 +94,13 @@ next(path::GtkTreePath) = ccall((:gtk_tree_path_next,libgtk), Void, (Ptr{GtkTree
 prev(path::GtkTreePath) = ccall((:gtk_tree_path_prev,libgtk),Cint, (Ptr{GtkTreePath},),path) != 0
 up(path::GtkTreePath) = ccall((:gtk_tree_path_up,libgtk),Cint, (Ptr{GtkTreePath},),path) != 0
 down(path::GtkTreePath) = ccall((:gtk_tree_path_down,libgtk), Void, (Ptr{GtkTreePath},),path)
-string(path::GtkTreePath) = bytestring( ccall((:gtk_tree_path_to_string,libgtk),Ptr{Uint8},
+string(path::GtkTreePath) = bytestring( ccall((:gtk_tree_path_to_string,libgtk),Ptr{UInt8},
                                             (Ptr{GtkTreePath},),path))
 
 ### add indices for a store 1-based
 
 ## Get an iter corresponding to an index specified as a string
-function iter_from_string_index(store, index::String)
+function iter_from_string_index(store, index::AbstractString)
     iter = Gtk.mutable(GtkTreeIter)
     Gtk.G_.iter_from_string(GtkTreeModel(store), iter, index)
     if !isvalid(store, iter)
@@ -434,7 +434,7 @@ end
 
 ## string is of type "0:1:0" (0-based)
 function get_string_from_iter(treeModel::GtkTreeModel, iter::TRI)
-    val = ccall((:gtk_tree_model_get_string_from_iter, libgtk),  Ptr{Uint8},
+    val = ccall((:gtk_tree_model_get_string_from_iter, libgtk),  Ptr{UInt8},
           (Ptr{GObject},Ptr{GtkTreeIter}),
           treeModel, mutable(iter))
     val = bytestring(val)
@@ -459,21 +459,21 @@ index_from_iter(treeModel::GtkTreeModel, iter::TRI) = map(int, split(get_string_
 type TreeIterator
     store::GtkTreeStore
     model::GtkTreeModel
-    iter::Union(Nothing, TRI)
+    iter::Union(Void, TRI)
 end
 TreeIterator(store::GtkTreeStore, iter=nothing) = TreeIterator(store, GtkTreeModel(store), iter)
 
 
 ## iterator interface for depth first search
 function start(x::TreeIterator)
-    isa(x.iter, Nothing) ? nothing : mutable(copy(x.iter))
+    isa(x.iter, Void) ? nothing : mutable(copy(x.iter))
 end
 
 function done(x::TreeIterator, state)
 
     iter = mutable(GtkTreeIter)
 
-    isa(state, Nothing) && return (!Gtk.get_iter_first(x.model, iter))   # special case root
+    isa(state, Void) && return (!Gtk.get_iter_first(x.model, iter))   # special case root
 
     state = copy(state)
 
@@ -484,7 +484,7 @@ function done(x::TreeIterator, state)
     # or a valid ancestor of piter has a sibling
     up(x.model, state) || return(true)
 
-    while isa(x.iter, Nothing) || isancestor(x.store, x.iter, state)
+    while isa(x.iter, Void) || isancestor(x.store, x.iter, state)
         next(x.model, copy(state)) && return(false) # has a sibling
         up(x.model, state) || return(true)
     end
@@ -495,7 +495,7 @@ end
 function next(x::TreeIterator, state)
     iter = mutable(GtkTreeIter)
 
-    if isa(state, Nothing)      # special case root
+    if isa(state, Void)      # special case root
         Gtk.get_iter_first(x.model, iter)
         return(iter, iter)
     end
@@ -512,7 +512,7 @@ function next(x::TreeIterator, state)
 
     up(x.model, state)
 
-    while isa(x.iter, Nothing) || isancestor(x.store, x.iter, state)
+    while isa(x.iter, Void) || isancestor(x.store, x.iter, state)
         cstate = copy(state)
         next(x.model, cstate) && return(cstate, cstate) # return the sibling of state
         up(x.model, state)
@@ -581,7 +581,7 @@ function GtkTreeViewColumnLeaf(renderer::GtkCellRenderer, mapping)
     treeColumn
 end
 
-function GtkTreeViewColumnLeaf(title::String, renderer::GtkCellRenderer, mapping)
+function GtkTreeViewColumnLeaf(title::AbstractString, renderer::GtkCellRenderer, mapping)
     setproperty!(GtkTreeViewColumnLeaf(renderer,mapping), :title, title)
 end
 
@@ -601,9 +601,9 @@ function push!(treeColumn::GtkTreeViewColumn, renderer::GtkCellRenderer, expand:
 end
 
 add_attribute(treeColumn::GtkTreeViewColumn, renderer::GtkCellRenderer,
-              attribute::String, column::Integer) =
+              attribute::AbstractString, column::Integer) =
     ccall((:gtk_tree_view_column_add_attribute,libgtk),Void,
-          (Ptr{GObject},Ptr{GObject},Ptr{Uint8},Cint),treeColumn,renderer,bytestring(attribute),column)
+          (Ptr{GObject},Ptr{GObject},Ptr{UInt8},Cint),treeColumn,renderer,bytestring(attribute),column)
 
 ### GtkTreeSelection
 function selected(selection::GtkTreeSelection)

--- a/src/menus.jl
+++ b/src/menus.jl
@@ -20,9 +20,9 @@
 #GtkRadioToolButton — A toolbar item that contains a radio button
 
 GtkMenuItemLeaf() = GtkMenuItemLeaf(ccall((:gtk_menu_item_new,libgtk),Ptr{GObject},()))
-GtkMenuItemLeaf(label::String) =
+GtkMenuItemLeaf(label::AbstractString) =
     GtkMenuItemLeaf(ccall((:gtk_menu_item_new_with_mnemonic,libgtk),Ptr{GObject},
-                (Ptr{Uint8},), bytestring(label)))
+                (Ptr{UInt8},), bytestring(label)))
 
 GtkSeparatorMenuItemLeaf() = GtkSeparatorMenuItemLeaf(ccall((:gtk_separator_menu_item_new,libgtk),Ptr{GObject},()))
 
@@ -39,5 +39,5 @@ GtkMenuBarLeaf() = GtkMenuBarLeaf(ccall((:gtk_menu_bar_new,libgtk),Ptr{GObject},
 
 popup(menu::GtkMenuShell, event::GdkEventButton) =
     ccall((:gtk_menu_popup,libgtk), Void,
-          (Ptr{GObject},Ptr{GObject},Ptr{GObject},Ptr{GObject},Ptr{Void},Cuint,Uint32),
+          (Ptr{GObject},Ptr{GObject},Ptr{GObject},Ptr{GObject},Ptr{Void},Cuint,UInt32),
           menu, GtkNullContainerLeaf(), GtkNullContainerLeaf(), GtkNullContainerLeaf(), C_NULL, event.button, event.time)

--- a/src/selectors.jl
+++ b/src/selectors.jl
@@ -14,19 +14,19 @@
 #GtkFontSelectionDialog — A dialog box for selecting fonts
 #GtkInputDialog — Configure devices for the XInput extension
 
-function push!(widget::GtkDialog, text::String, response::Integer)
+function push!(widget::GtkDialog, text::AbstractString, response::Integer)
     ccall((:gtk_dialog_add_button,libgtk), Ptr{GObject},
-          (Ptr{GObject},Ptr{Uint8},Cint), widget, text, response)
+          (Ptr{GObject},Ptr{UInt8},Cint), widget, text, response)
     widget
 end
 
 #if VERSION >= v"0.4-"
-#GtkFileChooserDialogLeaf(title::String, parent::GtkContainer, action::Integer, button_text_response::=>...; kwargs...) =
-#    GtkFileChooserDialogLeaf(title::String, parent, action, button_text_response; kwargs...)
+#GtkFileChooserDialogLeaf(title::AbstractString, parent::GtkContainer, action::Integer, button_text_response::=>...; kwargs...) =
+#    GtkFileChooserDialogLeaf(title::AbstractString, parent, action, button_text_response; kwargs...)
 #end
-function GtkFileChooserDialogLeaf(title::String, parent::GtkContainer, action::Integer, button_text_response; kwargs...)
+function GtkFileChooserDialogLeaf(title::AbstractString, parent::GtkContainer, action::Integer, button_text_response; kwargs...)
     w = GtkFileChooserDialogLeaf(ccall((:gtk_file_chooser_dialog_new,libgtk), Ptr{GObject},
-                (Ptr{Uint8},Ptr{GObject},Cint,Ptr{Void}),
+                (Ptr{UInt8},Ptr{GObject},Cint,Ptr{Void}),
                 title, parent, action, C_NULL); kwargs...)
     for (k,v) in button_text_response
         push!(w, k, v)
@@ -39,27 +39,27 @@ run(widget::GtkDialog) = GLib.g_sigatom() do
 end
 
 const SingleComma = r"(?<!,),(?!,)"
-function GtkFileFilterLeaf(; name::Union(ByteString,Nothing) = nothing, pattern::ByteString = "", mimetype::ByteString = "")
+function GtkFileFilterLeaf(; name::Union(ByteString,Void) = nothing, pattern::ByteString = "", mimetype::ByteString = "")
     filt = GtkFileFilterLeaf(ccall((:gtk_file_filter_new,libgtk), Ptr{GObject}, ()))
     if !isempty(pattern)
         name == nothing && (name = pattern)
         for p in split(pattern, SingleComma)
             p = replace(p, ",,", ",")   # escape sequence for , is ,,
-            ccall((:gtk_file_filter_add_pattern,libgtk), Void, (Ptr{GObject}, Ptr{Uint8}), filt, p)
+            ccall((:gtk_file_filter_add_pattern,libgtk), Void, (Ptr{GObject}, Ptr{UInt8}), filt, p)
         end
     elseif !isempty(mimetype)
         name == nothing && (name = mimetype)
         for m in split(mimetype, SingleComma)
             m = replace(m, ",,", ",")
-            ccall((:gtk_file_filter_add_mime_type,libgtk), Void, (Ptr{GObject}, Ptr{Uint8}), filt, m)
+            ccall((:gtk_file_filter_add_mime_type,libgtk), Void, (Ptr{GObject}, Ptr{UInt8}), filt, m)
         end
     else
         ccall((:gtk_file_filter_add_pixbuf_formats,libgtk), Void, (Ptr{GObject},), filt)
     end
-    ccall((:gtk_file_filter_set_name,libgtk), Void, (Ptr{GObject}, Ptr{Uint8}), filt, isempty(name) || name==nothing ? C_NULL : name)
+    ccall((:gtk_file_filter_set_name,libgtk), Void, (Ptr{GObject}, Ptr{UInt8}), filt, isempty(name) || name==nothing ? C_NULL : name)
     filt
 end
-GtkFileFilterLeaf(pattern::ByteString; name::Union(ByteString,Nothing) = nothing) = GtkFileFilterLeaf(; name=name, pattern=pattern)
+GtkFileFilterLeaf(pattern::ByteString; name::Union(ByteString,Void) = nothing) = GtkFileFilterLeaf(; name=name, pattern=pattern)
 
 GtkFileFilterLeaf(filter::GtkFileFilter) = filter
 
@@ -69,7 +69,7 @@ function makefilters!(dlgp::GtkFileChooser, filters::Union(AbstractVector,Tuple)
     end
 end
 
-function open_dialog(title::String, parent = GtkNullContainer(), filters::Union(AbstractVector,Tuple) = ASCIIString[]; kwargs...)
+function open_dialog(title::AbstractString, parent = GtkNullContainer(), filters::Union(AbstractVector,Tuple) = ASCIIString[]; kwargs...)
     dlg = @GtkFileChooserDialog(title, parent, GConstants.GtkFileChooserAction.OPEN,
                                 (("_Cancel", GConstants.GtkResponseType.CANCEL),
                                  ("_Open",   GConstants.GtkResponseType.ACCEPT)); kwargs...)
@@ -83,7 +83,7 @@ function open_dialog(title::String, parent = GtkNullContainer(), filters::Union(
     if response == GConstants.GtkResponseType.ACCEPT
         if multiple
             selection = UTF8String[]
-            for f in GLib.GList(ccall((:gtk_file_chooser_get_filenames,libgtk), Ptr{_GSList{Uint8}}, (Ptr{GObject},), dlgp))
+            for f in GLib.GList(ccall((:gtk_file_chooser_get_filenames,libgtk), Ptr{_GSList{UInt8}}, (Ptr{GObject},), dlgp))
                 push!(selection, GLib.bytestring(f, true))
             end
         else
@@ -100,7 +100,7 @@ function open_dialog(title::String, parent = GtkNullContainer(), filters::Union(
     selection
 end
 
-function save_dialog(title::String, parent = GtkNullContainer(), filters::Union(AbstractVector,Tuple) = ASCIIString[]; kwargs...)
+function save_dialog(title::AbstractString, parent = GtkNullContainer(), filters::Union(AbstractVector,Tuple) = ASCIIString[]; kwargs...)
     dlg = @GtkFileChooserDialog(title, parent, GConstants.GtkFileChooserAction.SAVE,
                                 (("_Cancel", GConstants.GtkResponseType.CANCEL),
                                  ("_Save",   GConstants.GtkResponseType.ACCEPT)), kwargs...)

--- a/src/text.jl
+++ b/src/text.jl
@@ -14,7 +14,7 @@
 #TODO: GtkAccel manager objects
 
 GtkLabelLeaf(title) = GtkLabelLeaf(
-    ccall((:gtk_label_new,libgtk),Ptr{GObject},(Ptr{Uint8},), bytestring(title)))
+    ccall((:gtk_label_new,libgtk),Ptr{GObject},(Ptr{UInt8},), bytestring(title)))
 
 GtkTextBufferLeaf() = GtkTextBufferLeaf(
     ccall((:gtk_text_buffer_new,libgtk),Ptr{GObject},(Ptr{GObject},),C_NULL))
@@ -23,12 +23,12 @@ GtkTextViewLeaf(buffer::GtkTextBuffer=@GtkTextBuffer()) = GtkTextViewLeaf(
     ccall((:gtk_text_view_new_with_buffer,libgtk),Ptr{GObject},(Ptr{GObject},),buffer))
 
 GtkTextMarkLeaf(left_gravity::Bool=false) = GtkTextMarkLeaf(
-    ccall((:gtk_text_mark_new,libgtk),Ptr{GObject},(Ptr{Uint8},Cint),C_NULL,left_gravity))
+    ccall((:gtk_text_mark_new,libgtk),Ptr{GObject},(Ptr{UInt8},Cint),C_NULL,left_gravity))
 
 GtkTextTagLeaf() = GtkTextTagLeaf(
-    ccall((:gtk_text_tag_new,libgtk),Ptr{GObject},(Ptr{Uint8},),C_NULL))
-GtkTextTagLeaf(name::String) = GtkTextTagLeaf(
-    ccall((:gtk_text_tag_new,libgtk),Ptr{GObject},(Ptr{Uint8},),bytestring(name)))
+    ccall((:gtk_text_tag_new,libgtk),Ptr{GObject},(Ptr{UInt8},),C_NULL))
+GtkTextTagLeaf(name::AbstractString) = GtkTextTagLeaf(
+    ccall((:gtk_text_tag_new,libgtk),Ptr{GObject},(Ptr{UInt8},),bytestring(name)))
 
 immutable GtkTextIter
   dummy1::Ptr{Void}
@@ -90,7 +90,7 @@ end
 
 #####  GtkTextIter  #####
 #TODO: search
-getproperty(text::TI, key::String, outtype::Type=Any) = getproperty(text, symbol(key), outtype)
+getproperty(text::TI, key::AbstractString, outtype::Type=Any) = getproperty(text, symbol(key), outtype)
 function getproperty(text::TI, key::Symbol, outtype::Type=Any)
     text = mutable(text)
     return convert(outtype,
@@ -150,7 +150,7 @@ function getproperty(text::TI, key::Symbol, outtype::Type=Any)
     elseif key === :is_start
         bool(ccall((:gtk_text_iter_is_start,libgtk),Cint,(Ptr{GtkTextIter},),text))
     elseif key === :char
-        convert(Char,ccall((:gtk_text_iter_get_char,libgtk),Uint32,(Ptr{GtkTextIter},),text))
+        convert(Char,ccall((:gtk_text_iter_get_char,libgtk),UInt32,(Ptr{GtkTextIter},),text))
     elseif key === :pixbuf
         convert(GdkPixbuf,ccall((:gtk_text_iter_get_char,libgtk),Ptr{GdkPixbuf},(Ptr{GtkTextIter},),text))
     else
@@ -158,7 +158,7 @@ function getproperty(text::TI, key::Symbol, outtype::Type=Any)
         false
     end)::outtype
 end
-setproperty!(text::Mutable{GtkTextIter},key::String,value) = setproperty!(text,symbol(key),value)
+setproperty!(text::Mutable{GtkTextIter},key::AbstractString,value) = setproperty!(text,symbol(key),value)
 function setproperty!(text::Mutable{GtkTextIter},key::Symbol,value)
     if     key === :offset
         ccall((:gtk_text_iter_set_offset,libgtk),Cint,(Ptr{GtkTextIter},Cint),text,value)
@@ -278,22 +278,22 @@ last(r::GtkTextRange) = r.b
 start(r::GtkTextRange) = start(first(r))
 next(r::GtkTextRange,i) = next(i,i)
 done(r::GtkTextRange,i) = (i==last(r) || done(i,i))
-getproperty(text::GtkTextRange, key::String, outtype::Type=Any) = getproperty(text, symbol(key), outtype)
+getproperty(text::GtkTextRange, key::AbstractString, outtype::Type=Any) = getproperty(text, symbol(key), outtype)
 function getproperty(text::GtkTextRange, key::Symbol, outtype::Type=Any)
     starttext = first(text)
     endtext = last(text)
     return convert(outtype,
     if     key === :slice
-        bytestring(ccall((:gtk_text_iter_get_slice,libgtk),Ptr{Uint8},
+        bytestring(ccall((:gtk_text_iter_get_slice,libgtk),Ptr{UInt8},
             (Ptr{GtkTextIter},Ptr{GtkTextIter}),starttext,endtext),true)
     elseif key === :visible_slice
-        bytestring(ccall((:gtk_text_iter_get_visible_slice,libgtk),Ptr{Uint8},
+        bytestring(ccall((:gtk_text_iter_get_visible_slice,libgtk),Ptr{UInt8},
             (Ptr{GtkTextIter},Ptr{GtkTextIter}),starttext,endtext),true)
     elseif key === :text
-        bytestring(ccall((:gtk_text_iter_get_text,libgtk),Ptr{Uint8},
+        bytestring(ccall((:gtk_text_iter_get_text,libgtk),Ptr{UInt8},
             (Ptr{GtkTextIter},Ptr{GtkTextIter}),starttext,endtext),true)
     elseif key === :visible_text
-        bytestring(ccall((:gtk_text_iter_get_visible_text,libgtk),Ptr{Uint8},
+        bytestring(ccall((:gtk_text_iter_get_visible_text,libgtk),Ptr{UInt8},
             (Ptr{GtkTextIter},Ptr{GtkTextIter}),starttext,endtext),true)
     end)::outtype
 end
@@ -316,14 +316,14 @@ done(text::GtkTextBuffer, iter) = done(iter,iter)
 length(text::GtkTextBuffer) = ccall((:gtk_text_buffer_get_char_count,libgtk),Cint,
     (Ptr{GObject},),text)
 #get_line_count(text::GtkTextBuffer) = ccall((:gtk_text_buffer_get_line_count,libgtk),Cint,(Ptr{GObject},),text)
-function insert!(text::GtkTextBuffer,index::TI,str::String)
+function insert!(text::GtkTextBuffer,index::TI,str::AbstractString)
     ccall((:gtk_text_buffer_insert,libgtk),Void,
-        (Ptr{GObject},Ptr{GtkTextIter},Ptr{Uint8},Cint),text,mutable(index),bytestring(str),sizeof(str))
+        (Ptr{GObject},Ptr{GtkTextIter},Ptr{UInt8},Cint),text,mutable(index),bytestring(str),sizeof(str))
     text
 end
-function insert!(text::GtkTextBuffer,str::String)
+function insert!(text::GtkTextBuffer,str::AbstractString)
     ccall((:gtk_text_buffer_insert_at_cursor,libgtk),Void,
-        (Ptr{GObject},Ptr{Uint8},Cint),text,bytestring(str),sizeof(str))
+        (Ptr{GObject},Ptr{UInt8},Cint),text,bytestring(str),sizeof(str))
     text
 end
 function splice!(text::GtkTextBuffer,index::TI)
@@ -352,9 +352,9 @@ function user_action(f::Function, buffer::GtkTextBuffer)
     end
 end
 
-function create_tag(buffer::GtkTextBuffer, tag_name::String; properties...)
+function create_tag(buffer::GtkTextBuffer, tag_name::AbstractString; properties...)
     tag = @GtkTextTag(ccall((:gtk_text_buffer_create_tag,libgtk), Ptr{GObject},
-                (Ptr{GObject},Ptr{Uint8},Ptr{Void}),
+                (Ptr{GObject},Ptr{UInt8},Ptr{Void}),
                 buffer, bytestring(tag_name), C_NULL))
     for (k,v) in properties
         setproperty!(tag, k, v)
@@ -362,15 +362,15 @@ function create_tag(buffer::GtkTextBuffer, tag_name::String; properties...)
     tag
 end
 
-function apply_tag(buffer::GtkTextBuffer, name::String, itstart::TI, itend::TI)
+function apply_tag(buffer::GtkTextBuffer, name::AbstractString, itstart::TI, itend::TI)
     ccall((:gtk_text_buffer_apply_tag_by_name,libgtk), Void,
-         (Ptr{GObject}, Ptr{Uint8}, Ptr{GtkTextIter}, Ptr{GtkTextIter}),
+         (Ptr{GObject}, Ptr{UInt8}, Ptr{GtkTextIter}, Ptr{GtkTextIter}),
          buffer, bytestring(name), mutable(itstart), mutable(itend))
 end
 
-function remove_tag(buffer::GtkTextBuffer, name::String, itstart::TI, itend::TI)
+function remove_tag(buffer::GtkTextBuffer, name::AbstractString, itstart::TI, itend::TI)
     ccall((:gtk_text_buffer_remove_tag_by_name,libgtk), Void,
-         (Ptr{GObject}, Ptr{Uint8}, Ptr{GtkTextIter}, Ptr{GtkTextIter}),
+         (Ptr{GObject}, Ptr{UInt8}, Ptr{GtkTextIter}, Ptr{GtkTextIter}),
          buffer, bytestring(name), mutable(itstart), mutable(itend))
 end
 
@@ -400,15 +400,15 @@ function insert!(text::GtkTextView,index::TI,child::GtkWidget)
     text
 end
 
-function insert!(text::GtkTextView,index::TI,str::String)
+function insert!(text::GtkTextView,index::TI,str::AbstractString)
     bool(ccall((:gtk_text_buffer_insert_interactive,libgtk),Cint,
-        (Ptr{GObject},Ptr{GtkTextIter},Ptr{Uint8},Cint,Cint),
+        (Ptr{GObject},Ptr{GtkTextIter},Ptr{UInt8},Cint,Cint),
         gtk_text_view_get_buffer(text),mutable(index),bytestring(str),sizeof(str),gtk_text_view_get_editable(text)))
     text
 end
-function insert!(text::GtkTextView,str::String)
+function insert!(text::GtkTextView,str::AbstractString)
     bool(ccall((:gtk_text_buffer_insert_interactive_at_cursor,libgtk),Cint,
-        (Ptr{GObject},Ptr{Uint8},Cint,Cint),
+        (Ptr{GObject},Ptr{UInt8},Cint,Cint),
         gtk_text_view_get_buffer(text),bytestring(str),sizeof(str),gtk_text_view_get_editable(text)))
     text
 end

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -9,13 +9,13 @@ function GtkCssProviderLeaf(;data=nothing,filename=nothing)
     if data !== nothing
         GError() do error_check
           ccall((:gtk_css_provider_load_from_data,libgtk), Bool,
-            (Ptr{GObject}, Ptr{Uint8}, Clong, Ptr{Ptr{GError}}),
+            (Ptr{GObject}, Ptr{UInt8}, Clong, Ptr{Ptr{GError}}),
             provider, bytestring(data), -1, error_check)
         end
     elseif filename !== nothing
         GError() do error_check
           ccall((:gtk_css_provider_load_from_path,libgtk), Bool,
-            (Ptr{GObject}, Ptr{Uint8}, Clong, Ptr{Ptr{GError}}),
+            (Ptr{GObject}, Ptr{UInt8}, Clong, Ptr{Ptr{GError}}),
             provider, bytestring(filename), error_check)
         end
     end

--- a/src/toolbar.jl
+++ b/src/toolbar.jl
@@ -33,18 +33,18 @@ length(toolbar::GtkToolbar) =
   ccall((:gtk_toolbar_get_n_items,libgtk),Cint,(Ptr{GObject},),toolbar)
 
 ### GtkToolButton
-GtkToolButtonLeaf(stock_id::String) = GtkToolButtonLeaf(
-    ccall((:gtk_tool_button_new_from_stock,libgtk),Ptr{GObject},(Ptr{Uint8},), bytestring(stock_id)))
+GtkToolButtonLeaf(stock_id::AbstractString) = GtkToolButtonLeaf(
+    ccall((:gtk_tool_button_new_from_stock,libgtk),Ptr{GObject},(Ptr{UInt8},), bytestring(stock_id)))
 
-GtkToggleToolButtonLeaf(stock_id::String) = GtkToggleToolButtonLeaf(
-    ccall((:gtk_toggle_tool_button_new_from_stock,libgtk),Ptr{GObject},(Ptr{Uint8},), bytestring(stock_id)))
+GtkToggleToolButtonLeaf(stock_id::AbstractString) = GtkToggleToolButtonLeaf(
+    ccall((:gtk_toggle_tool_button_new_from_stock,libgtk),Ptr{GObject},(Ptr{UInt8},), bytestring(stock_id)))
 GtkToggleToolButtonLeaf() = GtkToggleToolButtonLeaf(
     ccall((:gtk_toggle_tool_button_new,libgtk),Ptr{GObject},()))
 
 #TODO GtkRadioToolButton (needs _GSList as argument)
 
-GtkMenuToolButtonLeaf(stock_id::String) = GtkMenuToolButtonLeaf(
-    ccall((:gtk_menu_tool_button_new_from_stock,libgtk),Ptr{GObject},(Ptr{Uint8},), bytestring(stock_id)))
+GtkMenuToolButtonLeaf(stock_id::AbstractString) = GtkMenuToolButtonLeaf(
+    ccall((:gtk_menu_tool_button_new_from_stock,libgtk),Ptr{GObject},(Ptr{UInt8},), bytestring(stock_id)))
 
 ### GtkSeparatorToolItem
 GtkSeparatorToolItemLeaf() = GtkSeparatorToolItemLeaf(

--- a/src/windows.jl
+++ b/src/windows.jl
@@ -1,8 +1,8 @@
-function GtkWindowLeaf(title::Union(Nothing,StringLike)=nothing, w::Real=-1, h::Real=-1, resizable::Bool=true, toplevel::Bool=true)
+function GtkWindowLeaf(title::Union(Void,AbstractStringLike)=nothing, w::Real=-1, h::Real=-1, resizable::Bool=true, toplevel::Bool=true)
     hnd = ccall((:gtk_window_new,libgtk),Ptr{GObject},(GEnum,),
         toplevel?GtkWindowType.TOPLEVEL:GtkWindowType.POPUP)
     if title !== nothing
-        ccall((:gtk_window_set_title,libgtk),Void,(Ptr{GObject},Ptr{Uint8}),hnd,title)
+        ccall((:gtk_window_set_title,libgtk),Void,(Ptr{GObject},Ptr{UInt8}),hnd,title)
     end
     if resizable
         ccall((:gtk_window_set_default_size,libgtk),Void,(Ptr{GObject},Int32,Int32),hnd,w,h)
@@ -34,12 +34,12 @@ GtkScrolledWindowLeaf() = GtkScrolledWindowLeaf(
                 C_NULL,C_NULL))
 
 #if VERSION >= v"0.4-"
-#GtkDialogLeaf(title::StringLike, parent::GtkContainer, flags::Integer, buttons::=>...; kwargs...) =
+#GtkDialogLeaf(title::AbstractStringLike, parent::GtkContainer, flags::Integer, buttons::=>...; kwargs...) =
 #    GtkDialogLeaf(title, parent, flags, buttons; kwargs...)
 #end
-function GtkDialogLeaf(title::StringLike, parent::GtkContainer, flags::Integer, buttons; kwargs...)
+function GtkDialogLeaf(title::AbstractStringLike, parent::GtkContainer, flags::Integer, buttons; kwargs...)
     w = GtkDialogLeaf(ccall((:gtk_dialog_new_with_buttons,libgtk), Ptr{GObject},
-                (Ptr{Uint8},Ptr{GObject},Cint,Ptr{Void}),
+                (Ptr{UInt8},Ptr{GObject},Cint,Ptr{Void}),
                 title, parent, flags, C_NULL); kwargs...)
     for (k,v) in buttons
         push!(w, k, v)
@@ -50,9 +50,9 @@ end
 GtkAboutDialogLeaf() = GtkAboutDialogLeaf(
     ccall((:gtk_about_dialog_new,libgtk),Ptr{GObject},()))
 
-function GtkMessageDialogLeaf(message::StringLike, buttons, flags::Integer, typ::Integer, parent = GtkNullContainer(); kwargs...)
+function GtkMessageDialogLeaf(message::AbstractStringLike, buttons, flags::Integer, typ::Integer, parent = GtkNullContainer(); kwargs...)
     w = GtkMessageDialogLeaf(ccall((:gtk_message_dialog_new,libgtk), Ptr{GObject},
-        (Ptr{GObject},Cint,Cint,Cint,Ptr{Uint8}),
+        (Ptr{GObject},Cint,Cint,Cint,Ptr{UInt8}),
         parent, flags, typ, GtkButtonsType.NONE, C_NULL); kwargs...)
     setproperty!(w, :text, message)
     for (k,v) in buttons
@@ -61,10 +61,10 @@ function GtkMessageDialogLeaf(message::StringLike, buttons, flags::Integer, typ:
     w
 end
 
-ask_dialog(message::String, parent = GtkNullContainer()) =
+ask_dialog(message::AbstractString, parent = GtkNullContainer()) =
         ask_dialog(message, "No", "Yes", parent)
 
-function ask_dialog(message::String, no_text, yes_text, parent = GtkNullContainer())
+function ask_dialog(message::AbstractString, no_text, yes_text, parent = GtkNullContainer())
     dlg = @GtkMessageDialog(message, ((no_text,0), (yes_text,1)),
             GtkDialogFlags.DESTROY_WITH_PARENT, GtkMessageType.QUESTION, parent)
     response = run(dlg)
@@ -76,9 +76,9 @@ for (func, flag) in (
         (:info_dialog, :(GtkMessageType.INFO)),
         (:warn_dialog, :(GtkMessageType.WARNING)),
         (:error_dialog, :(GtkMessageType.ERROR)))
-    @eval function $func(message::String, parent = GtkNullContainer())
+    @eval function $func(message::AbstractString, parent = GtkNullContainer())
         w = GtkMessageDialogLeaf(ccall((:gtk_message_dialog_new,libgtk), Ptr{GObject},
-            (Ptr{GObject},Cint,Cint,Cint,Ptr{Uint8}),
+            (Ptr{GObject},Cint,Cint,Cint,Ptr{UInt8}),
             parent, GtkDialogFlags.DESTROY_WITH_PARENT,
             $flag, GtkButtonsType.CLOSE, C_NULL))
         setproperty!(w, :text, message)
@@ -87,7 +87,7 @@ for (func, flag) in (
     end
 end
 
-function input_dialog(message::String, entry_default::String, buttons=(("Cancel",0), ("Accept",1)), parent = GtkNullContainer())
+function input_dialog(message::AbstractString, entry_default::AbstractString, buttons=(("Cancel",0), ("Accept",1)), parent = GtkNullContainer())
     widget = @GtkMessageDialog(message, buttons, GtkDialogFlags.DESTROY_WITH_PARENT, GtkMessageType.INFO, parent)
     box = content_area(widget)
     entry = @GtkEntry(;text=entry_default)

--- a/test/gui.jl
+++ b/test/gui.jl
@@ -17,9 +17,9 @@ sleep(0.1)
 if G_.position(w) == pos
     warn("The Window Manager did not move the Gtk Window when requested")
 end
-@assert getproperty(w,"title",String) == "Window"
+@assert getproperty(w,"title",AbstractString) == "Window"
 setproperty!(w,:title,"Window 2")
-@assert getproperty(w,:title,String) == "Window 2"
+@assert getproperty(w,:title,AbstractString) == "Window 2"
 destroy(w)
 @assert !getproperty(w,:visible,Bool)
 w=WeakRef(w)
@@ -49,7 +49,7 @@ destroy(w)
 f = @Frame("Label")
 w = @Window(f, "Labelframe", 400, 400)
 setproperty!(f,:label,"new label")
-@assert getproperty(f,:label,String) == "new label"
+@assert getproperty(f,:label,AbstractString) == "new label"
 showall(w)
 destroy(w)
 
@@ -102,7 +102,7 @@ push!(g2, b22)
 strs = ["first", "second"]
 i = 1
 for child in g1
-    @assert getproperty(child,:label,String) == strs[i]
+    @assert getproperty(child,:label,AbstractString) == strs[i]
     @assert toplevel(child) == w
     i += 1
 end
@@ -149,9 +149,9 @@ l = @Label("label"); push!(f,l)
 b = @Button("button"); push!(f,b)
 
 setproperty!(l,:label,"new label")
-@assert getproperty(l,:label,String) == "new label"
+@assert getproperty(l,:label,AbstractString) == "new label"
 setproperty!(b,:label,"new label")
-@assert getproperty(b,:label,String) == "new label"
+@assert getproperty(b,:label,AbstractString) == "new label"
 
 counter = 0
 id = signal_connect(b, "clicked") do widget
@@ -189,9 +189,9 @@ destroy(w)
 w = @Window("Checkbutton")
 check = @CheckButton("check me"); push!(w,check)
 setproperty!(check,:active,true)
-@assert getproperty(check,:active,String) == "TRUE"
+@assert getproperty(check,:active,AbstractString) == "TRUE"
 setproperty!(check,:label,"new label")
-@assert getproperty(check,:label,String) == "new label"
+@assert getproperty(check,:label,AbstractString) == "new label"
 #ctr = 0
 #tk_bind(check, "command", cb)
 #tcl(check, "invoke")
@@ -219,14 +219,14 @@ r = @RadioButtonGroup(choices,2)
 itms = Array(Any,length(r))
 for (i,e) in enumerate(r)
     itms[i] = try
-            getproperty(e,:label,String)
+            getproperty(e,:label,AbstractString)
         catch
             e[1]
         end
 end
 @assert setdiff(choices, itms) == [choices[4],]
 @assert setdiff(itms, choices) == ["choice four",]
-@assert getproperty(getproperty(r,:active),:label,String) == choices[2]
+@assert getproperty(getproperty(r,:active),:label,AbstractString) == choices[2]
 w = @Window(r,"RadioGroup")|>showall
 destroy(w)
 
@@ -234,7 +234,7 @@ destroy(w)
 tb = @ToggleButton("Off")
 w = @Window(tb, "ToggleButton")|>showall
 function toggled(ptr,evt,widget)
-    state = getproperty(widget,:label,String)
+    state = getproperty(widget,:label,AbstractString)
     if state == "Off"
         setproperty!(widget,:label,"On")
     else
@@ -254,7 +254,7 @@ destroy(w)
 tb = @ToggleButton("Off")
 w = @Window(tb, "ToggleButton")|>showall
 on_signal_button_press(tb) do ptr, evt, widget
-    state = getproperty(widget,:label,String)
+    state = getproperty(widget,:label,AbstractString)
     if state == "Off"
         setproperty!(widget,:label,"On")
     else
@@ -273,7 +273,7 @@ destroy(w)
 tb = @ToggleButton("Off")
 w = @Window(tb, "ToggleButton")|>showall
 signal_connect(tb, :button_press_event) do widget, evt
-    state = getproperty(widget,:label,String)
+    state = getproperty(widget,:label,AbstractString)
     if state == "Off"
         setproperty!(widget,:label,"On")
     else
@@ -499,7 +499,7 @@ destroy(w)
 
 
 ## Tree view
-ts=@TreeStore(String)
+ts=@TreeStore(AbstractString)
 iter1 = push!(ts,("one",))
 iter2 = push!(ts,("two",),iter1)
 iter3 = push!(ts,("three",),iter2)


### PR DESCRIPTION
With the new binding deprecation warnings, this package has gotten very noisy. This fixes the problem on julia 0.4. julia 0.3 is more problematic, particularly because we can't easily use the `Compat` package due to an internal module called `Compat`. So I'm proposing the simple expedient of switching master to require julia 0.4-. If you like that idea, I can separately push a julia-0.3 branch.