### PR TITLE
Fix userimg: don't check isinteractive in __init__ (fixes #198)

### DIFF
--- a/src/events.jl
+++ b/src/events.jl
@@ -15,7 +15,7 @@ function __init__()
 
     # if g_main_depth > 0, a glib main-loop is already running,
     # so we don't need to start a new one
-    if ccall((:g_main_depth,GLib.libglib),Cint,()) == 0 && isinteractive()
+    if ccall((:g_main_depth,GLib.libglib),Cint,()) == 0
         global gtk_main_task = schedule(Task(gtk_main))
     end
 end


### PR DESCRIPTION
I'm not certain whether this `isinteractive` check is needed for typical use, but deleting it didn't seem to break the tests.